### PR TITLE
Added angular test coverage

### DIFF
--- a/angular/angular.json
+++ b/angular/angular.json
@@ -144,6 +144,7 @@
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
             "main": "projects/angular-library/src/test.ts",
+            "codeCoverage": true,
             "tsConfig": "projects/angular-library/tsconfig.spec.json",
             "karmaConfig": "projects/angular-library/karma.conf.js"
           }

--- a/angular/projects/angular-library/karma.conf.js
+++ b/angular/projects/angular-library/karma.conf.js
@@ -18,7 +18,13 @@ module.exports = function (config) {
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '../../coverage'),
       reports: ['html', 'lcovonly'],
-      fixWebpackSourcePaths: true
+      fixWebpackSourcePaths: true,
+      thresholds: {
+        statements: 75,
+        lines: 80,
+        branches: 59,
+        functions: 80
+      }
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,


### PR DESCRIPTION
Added angular test coverage
A few things to note 
1. Angular coverage test will now run automatically when the test is run
2. coverage for some portions is low. That being said we have a ticket in place to add more tests and this limit will be raised as well. 