### PR TITLE
Update react version to be ^16.8.3 || ^17.0.0

### DIFF
--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -20,7 +20,7 @@
     "test-coverage": "jest --coverage"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.8.3 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.12.10",

--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -20,7 +20,7 @@
     "test-coverage": "jest --coverage"
   },
   "peerDependencies": {
-    "react": "^16.8.3 || ^17.0.0"
+    "react": "^16.3.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.12.10",


### PR DESCRIPTION
This pr fixes an issue where installing the react npm package when using react 17 fails due to dependency conflict