### PR TITLE
fix status canceled error on placeholder

### DIFF
--- a/frameworks/html/src/plugins/placeholder.ts
+++ b/frameworks/html/src/plugins/placeholder.ts
@@ -40,7 +40,10 @@ function placeholderPlugin(mode: placeholderMode, element: HTMLImageElement, plu
     element.src = singleTransparentPixel;
   };
 
-  //ensure placeholder image loads first
+  /*
+  Placeholder image loads first. Once it loads, the promise is resolved and the
+  larger image will load. Once the larger image loads, promised and plugin is resolved.
+   */
   return new Promise((resolve: any) => {
     element.onload = () => {
       resolve();

--- a/frameworks/react/__tests__/placeholder.test.tsx
+++ b/frameworks/react/__tests__/placeholder.test.tsx
@@ -74,6 +74,11 @@ describe('placeholder', () => {
     }, 0);// one tick
   });
 
+  /*
+  This test is built with two setTimouts since the placeholder plugin makes use of two promises.
+  The placeholder image loads first. Once it loads, the promise is resolved and the
+  larger image will load. Once the larger image loads, promised and plugin is resolved.
+   */
   it('should not fail error', function (done) {
     const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder()]} />);
     setTimeout(() => {


### PR DESCRIPTION
When the original image loads before the placeholder we get a canceled status error. 
To fix this, we ensured that the placeholder loads before the original image