### PR TITLE
Add responsive unit tests for svelte sdk

### DIFF
--- a/frameworks/svelte/__tests__/responsive.test.ts
+++ b/frameworks/svelte/__tests__/responsive.test.ts
@@ -1,0 +1,108 @@
+import waitForExpect from 'wait-for-expect';
+import { crop } from '@cloudinary/base/actions/resize';
+import {CloudinaryImage} from '@cloudinary/base/assets/CloudinaryImage';
+import {responsive} from '../src/index';
+import {default as MockWrapper} from './testUtils/ResponsiveHelperWrapper.svelte';
+import {getImageAttr, mount, getElement, dispatchResize} from "./testUtils/testUtils";
+
+const cloudinaryImage = new CloudinaryImage('sample', {cloudName: 'demo'});
+
+describe('responsive', () => {
+  it('should apply initial container width (default 250)', async () => {
+    const {container} = await mount(MockWrapper, {
+      cldImg: cloudinaryImage,
+      advancedImgProps: {plugins: [responsive()]}
+    });
+
+    const el = getElement(container, '#wrapper');
+    await waitForExpect(() => {
+      expect(el.clientWidth).toBe(250);
+    });
+  });
+
+  it('should update container width on window resize', async () => {
+    const {container} = await mount(MockWrapper, {
+      cldImg: cloudinaryImage,
+      advancedImgProps: {plugins: [responsive()]}
+    });
+
+    let el = dispatchResize(container, 100);
+    await waitForExpect(() => {
+      expect(el.clientWidth).toBe(100);
+    });
+  });
+
+  it('should step by the 100th', async function () {
+    const {container} = await mount(MockWrapper, {
+      cldImg: cloudinaryImage,
+      advancedImgProps: {plugins: [responsive(100)]}
+    });
+
+    dispatchResize();
+
+    await waitForExpect(() => {
+      expect(getImageAttr(container, 'src')).toBe('https://res.cloudinary.com/demo/image/upload/c_scale,w_300/sample');
+    });
+  });
+
+  it('should step by breakpoints', async function () {
+    const {container} = await mount(MockWrapper, {
+      cldImg: cloudinaryImage,
+      advancedImgProps: {plugins: [responsive([800, 1000, 1200, 3000])]}
+    });
+
+    dispatchResize();
+
+    await waitForExpect(() => {
+      expect(getImageAttr(container, 'src')).toBe('https://res.cloudinary.com/demo/image/upload/c_scale,w_800/sample');
+    });
+
+    // simulate resize to 975
+    dispatchResize(container, 975);
+
+    await waitForExpect(() => {
+      expect(getImageAttr(container, 'src')).toBe('https://res.cloudinary.com/demo/image/upload/c_scale,w_1000/sample');
+    });
+  });
+
+  it('should not resize to larger than provided breakpoints', async function () {
+    const {container} = await mount(MockWrapper, {
+      cldImg: cloudinaryImage,
+      advancedImgProps: {plugins: [responsive([800, 1000, 1200, 3000])]}
+    });
+
+    dispatchResize(container, 4000);
+
+    await waitForExpect(() => {
+      expect(getImageAttr(container, 'src')).toBe('https://res.cloudinary.com/demo/image/upload/c_scale,w_3000/sample');
+    });
+  });
+
+  it('should handle unordered breakpoints', async function () {
+    const {container} = await mount(MockWrapper, {
+      cldImg: cloudinaryImage,
+      advancedImgProps: {plugins: [responsive([1000, 800, 3000, 1200])]}
+    });
+
+    dispatchResize(container, 5000);
+
+    await waitForExpect(() => {
+      expect(getImageAttr(container, 'src')).toBe('https://res.cloudinary.com/demo/image/upload/c_scale,w_3000/sample');
+    });
+  });
+
+  it('should append to existing transformation', async function () {
+    cloudinaryImage.resize(crop('500'));
+
+    const {container} = await mount(MockWrapper, {
+      cldImg: cloudinaryImage,
+      advancedImgProps: {plugins: [responsive()]}
+    });
+
+    dispatchResize();
+
+    await waitForExpect(() => {
+      expect(getImageAttr(container, 'src')).toBe('https://res.cloudinary.com/demo/image/upload/c_crop,w_500/c_scale,w_250/sample');
+    });
+  });
+});

--- a/frameworks/svelte/__tests__/testUtils/ResponsiveHelperWrapper.svelte
+++ b/frameworks/svelte/__tests__/testUtils/ResponsiveHelperWrapper.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  // Helper wrapper for responsive tests
+
+  import {AdvancedImage} from '../../src/index';
+  import {CloudinaryImage} from '@cloudinary/base/assets/CloudinaryImage';
+  import {onMount} from "svelte";
+
+  const cloudinaryImage = new CloudinaryImage('sample', {cloudName: 'demo'});
+  export let width: number = 250; //update container width
+  export let cldImg = undefined; //set child elements
+  export let advancedImgProps = {}; //set child element props
+  let div;
+
+  $: style = `width: ${width};`;
+
+  onMount(()=>{
+    Object.defineProperty(div, 'clientWidth', {value: 250, configurable: true});
+  });
+</script>
+
+<div bind:this={div} id="wrapper">
+    {#if cldImg}
+        <AdvancedImage cldImg={cldImg} {...advancedImgProps} />
+    {:else}
+        <slot />
+    {/if}
+</div>

--- a/frameworks/svelte/__tests__/testUtils/ResponsiveHelperWrapper.svelte
+++ b/frameworks/svelte/__tests__/testUtils/ResponsiveHelperWrapper.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   // Helper wrapper for responsive tests
+  // Svelte testing library does not yet support passing child components
+  // so we create the AdvancedImage using cldImg & advancedImgProps props
 
   import {AdvancedImage} from '../../src/index';
   import {CloudinaryImage} from '@cloudinary/base/assets/CloudinaryImage';
@@ -7,18 +9,16 @@
 
   const cloudinaryImage = new CloudinaryImage('sample', {cloudName: 'demo'});
   export let width: number = 250; //update container width
-  export let cldImg = undefined; //set child elements
+  export let cldImg = undefined; //set child element
   export let advancedImgProps = {}; //set child element props
-  let div;
-
-  $: style = `width: ${width};`;
+  let parentElement; // ref to wrapper div
 
   onMount(()=>{
-    Object.defineProperty(div, 'clientWidth', {value: 250, configurable: true});
+    Object.defineProperty(parentElement, 'clientWidth', {value: 250, configurable: true});
   });
 </script>
 
-<div bind:this={div} id="wrapper">
+<div bind:this={parentElement} id="wrapper">
     {#if cldImg}
         <AdvancedImage cldImg={cldImg} {...advancedImgProps} />
     {:else}

--- a/frameworks/svelte/__tests__/testUtils/testUtils.ts
+++ b/frameworks/svelte/__tests__/testUtils/testUtils.ts
@@ -3,9 +3,13 @@ import {render, RenderResult} from '@testing-library/svelte'
 import {testWithMockedIntersectionObserver} from '../../../../testUtils/setupIntersectionObserverMock';
 import type {SvelteComponentDev} from "svelte/internal";
 
-const getImageElement = (container: HTMLElement): HTMLImageElement => container.querySelector("img") || {} as HTMLImageElement;
+const getElement = (container: HTMLElement, type: string): HTMLElement => container.querySelector(type) || {} as HTMLElement;
+
+const getImageElement = (container: HTMLElement): HTMLImageElement => getElement(container, 'img') as HTMLImageElement;
 
 const getImageAttr = (container: HTMLElement, attr: string): any => ((getImageElement(container) || {}) as any)[attr];
+
+const getElementAttr = (container: HTMLElement, type: string, attr: string): any => ((getElement(container, type) || {}) as any)[attr];
 
 const mount = async (cmp?: typeof SvelteComponentDev, props?: any): Promise<RenderResult> => {
   const result = cmp ? render(cmp, props) : {};
@@ -13,4 +17,43 @@ const mount = async (cmp?: typeof SvelteComponentDev, props?: any): Promise<Rend
   return result as RenderResult;
 };
 
-export {testWithMockedIntersectionObserver, getImageElement, getImageAttr, mount};
+/**
+ * Resize given element and dispatch a window resize event
+ * @param element to resize
+ * @param width to set element's clientWidth to
+ * @return the modified element
+ */
+const resizeElement = (element?: any, width?: number) => {
+  if (element) {
+    Object.defineProperty(element, 'clientWidth', {value: width, configurable: true});
+  }
+  window.dispatchEvent(new Event('resize'));
+
+  return element;
+}
+
+/**
+ * Util function used to dispatch a resize event used in the responsive tests
+ * Resize #wrapper in given svelte container to given width and dispatch a window resize event.
+ * @param container
+ * @param width
+ * @return the modified element
+ */
+const dispatchResize = (container?: any, width?: number) => {
+  if (container) {
+    return resizeElement(getElement(container, '#wrapper'), width);
+  }
+
+  return resizeElement();
+}
+
+
+export {
+  testWithMockedIntersectionObserver,
+  getImageElement,
+  getImageAttr,
+  getElement,
+  getElementAttr,
+  mount,
+  dispatchResize
+};


### PR DESCRIPTION
This is the exact responsive tests we have for the react sdk, but for svelte.