### PR TITLE
added enableProdMode()

### DIFF
--- a/frameworks/angular/projects/cloudinary-library/src/lib/cloudinary.module.ts
+++ b/frameworks/angular/projects/cloudinary-library/src/lib/cloudinary.module.ts
@@ -1,6 +1,12 @@
-import { NgModule } from '@angular/core';
+import { NgModule, enableProdMode } from '@angular/core';
 import { CloudinaryImageComponent } from './cloudinary-image.component';
 import { CloudinaryVideoComponent } from './cloudinary-video.component';
+
+/**
+ * Enables production mode. Added to remove
+ * ng reflects from dom.
+ */
+enableProdMode();
 
 @NgModule({
   imports: [


### PR DESCRIPTION
ng-reflect-${name} attributes are added for debugging purposes and show the input bindings that a component/directive has declared in its class.

<img width="1375" alt="Screen Shot 2021-03-16 at 11 39 24" src="https://user-images.githubusercontent.com/28888221/111292382-cd038e00-8650-11eb-80a6-b8cbbc081dd7.png">

They exist only when debugging mode is used which is default mode for Angular. To disable them, we added  enableProdMode() which results in the following 

<img width="1121" alt="Screen Shot 2021-03-16 at 11 49 06" src="https://user-images.githubusercontent.com/28888221/111292428-d7258c80-8650-11eb-9879-cd07b43320fb.png">
