### PR TITLE
Add rollup devDependency to vue3 project

### DIFF
--- a/frameworks/vue/vue3/package.json
+++ b/frameworks/vue/vue3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudinary/vue",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.3",
   "repository": "https://github.com/cloudinary/frontend-frameworks",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
@@ -21,6 +21,7 @@
     "vue": "^3.0.0"
   },
   "devDependencies": {
+    "rollup": "^2.47.0",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@types/jest": "^24.0.19",


### PR DESCRIPTION
- Bumped version manually to beta.3 (to align with others)
- Add rollup Dev Dependency