### PR TITLE
remove-files-property-from-svelte-package.json

### DIFF
--- a/frameworks/svelte/package.json
+++ b/frameworks/svelte/package.json
@@ -30,10 +30,6 @@
     "svelte",
     "cloudinary"
   ],
-  "files": [
-    "src",
-    "dist"
-  ],
   "types": "dist/index.d.ts",
   "devDependencies": {
     "@babel/preset-env": "^7.12.13",

--- a/frameworks/svelte/package.json
+++ b/frameworks/svelte/package.json
@@ -9,10 +9,10 @@
   "bugs": {
     "url": "https://github.com/cloudinary/frontend-frameworks/issues"
   },
-  "svelte": "dist/index.umd.js",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "umd": "./dist/index.umd.js",
+  "svelte": "./index.umd.js",
+  "main": "./index.js",
+  "module": "./index.js",
+  "umd": "./index.umd.js",
   "sideEffects": false,
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Remove the files property from svelte's package.json

We're currently publishing from ./dist, which means these files don't exist, and that causes an empty package to publish (since there are no matched files).

Publishing from `./dist` will probably change when we move to a MonoRepo, but for now this aligns svelte to the other frameworks.