### PR TITLE
resolve broken ts imports

### DIFF
--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -20,10 +20,10 @@
     ],
     "paths": {
       "cloudinary-library": [
-        "dist/cloudinary-library"
+        "projects/cloudinary-library/dist"
       ],
       "cloudinary-library/*": [
-        "dist/cloudinary-library/*"
+        "projects/cloudinary-library/dist/*"
       ]
     }
   }


### PR DESCRIPTION
resolve broken ts imports

Since we're publishing dist we need to resolve the imports. 
right now we're getting an error with import {CloudinaryModule} from '@cloudinary/angular/';
meaning we need to include dist in our path  import {CloudinaryModule} from '@cloudinary/angular/';

to solve this we updated the tsconfig to the correct location
