### PR TITLE
Fix import of lodash.clonedeep

### DIFF
--- a/packages/html/src/layers/htmlImageLayer.ts
+++ b/packages/html/src/layers/htmlImageLayer.ts
@@ -1,6 +1,6 @@
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
-import {Plugins, HtmlPluginState} from '../types'
-import cloneDeep from 'lodash.cloneDeep'
+import {Plugins, HtmlPluginState} from '../types';
+import cloneDeep from 'lodash.clonedeep';
 import {render} from '../utils/render';
 
 export class HtmlImageLayer{

--- a/packages/html/src/layers/htmlImageLayer.ts
+++ b/packages/html/src/layers/htmlImageLayer.ts
@@ -1,6 +1,6 @@
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
 import {Plugins, HtmlPluginState} from '../types'
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'lodash.cloneDeep'
 import {render} from '../utils/render';
 
 export class HtmlImageLayer{

--- a/packages/html/src/layers/htmlVideoLayer.ts
+++ b/packages/html/src/layers/htmlVideoLayer.ts
@@ -1,5 +1,5 @@
 import {Plugins, HtmlPluginState, VideoSources, VideoType} from '../types'
-import cloneDeep from 'lodash.cloneDeep'
+import cloneDeep from 'lodash.clonedeep'
 import {CloudinaryVideo} from "@cloudinary/url-gen";
 import {render} from '../utils/render';
 import {VIDEO_MIME_TYPES} from "../utils/internalConstants";

--- a/packages/html/src/layers/htmlVideoLayer.ts
+++ b/packages/html/src/layers/htmlVideoLayer.ts
@@ -1,5 +1,5 @@
 import {Plugins, HtmlPluginState, VideoSources, VideoType} from '../types'
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'lodash.cloneDeep'
 import {CloudinaryVideo} from "@cloudinary/url-gen";
 import {render} from '../utils/render';
 import {VIDEO_MIME_TYPES} from "../utils/internalConstants";

--- a/packages/html/src/plugins/placeholder.ts
+++ b/packages/html/src/plugins/placeholder.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'lodash.cloneDeep'
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
 import {Plugin, HtmlPluginState} from "../types";
 import {PLACEHOLDER_IMAGE_OPTIONS, singleTransparentPixel} from '../utils/internalConstants';
@@ -21,7 +21,7 @@ export function placeholder(mode='vectorize'): Plugin{
 
 /**
  * @description Placeholder plugin
- * @param mode {placeholderMode} The type of placeholder image to display. Possible modes: 'vectorize' | 'pixelate' | 'blur' | 'predominant-color'. Default: 'vectorize'.
+ * @param mode {PlaceholderMode} The type of placeholder image to display. Possible modes: 'vectorize' | 'pixelate' | 'blur' | 'predominant-color'. Default: 'vectorize'.
  * @param element {HTMLImageElement} The image element.
  * @param pluginCloudinaryImage {CloudinaryImage}
  * @param htmlPluginState {htmlPluginState} Holds cleanup callbacks and event subscriptions.

--- a/packages/html/src/plugins/placeholder.ts
+++ b/packages/html/src/plugins/placeholder.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash.cloneDeep'
+import cloneDeep from 'lodash.clonedeep'
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
 import {Plugin, HtmlPluginState} from "../types";
 import {PLACEHOLDER_IMAGE_OPTIONS, singleTransparentPixel} from '../utils/internalConstants';

--- a/packages/html/src/utils/serverSideSrc.ts
+++ b/packages/html/src/utils/serverSideSrc.ts
@@ -5,7 +5,7 @@
  * @return {string} return the src
  */
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
-import cloneDeep from 'lodash.cloneDeep'
+import cloneDeep from 'lodash.clonedeep'
 import {Plugins} from "../types";
 
 export  function serverSideSrc(plugins?: Plugins, serverCloudinaryImage?: CloudinaryImage): string {

--- a/packages/html/src/utils/serverSideSrc.ts
+++ b/packages/html/src/utils/serverSideSrc.ts
@@ -5,7 +5,7 @@
  * @return {string} return the src
  */
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'lodash.cloneDeep'
 import {Plugins} from "../types";
 
 export  function serverSideSrc(plugins?: Plugins, serverCloudinaryImage?: CloudinaryImage): string {


### PR DESCRIPTION
This pr fixes import of lodash.clonedeep.
The import was from lodash/clonedeep, even though lodash.clonedeep is a dependency (see package.json)