### PR TITLE
add-plugin-input-as-object

### DIFF
--- a/packages/angular/projects/cloudinary-library/src/tests/accessibility.spec.ts
+++ b/packages/angular/projects/cloudinary-library/src/tests/accessibility.spec.ts
@@ -29,7 +29,7 @@ describe('accessibility', () => {
 
   it('should apply darkmode', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [accessibility('darkmode')];
+    component.plugins = [accessibility({mode: 'darkmode'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
@@ -39,7 +39,7 @@ describe('accessibility', () => {
 
   it('should apply brightmode', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [accessibility('brightmode')];
+    component.plugins = [accessibility({mode: 'brightmode'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
@@ -49,7 +49,7 @@ describe('accessibility', () => {
 
   it('should apply monochrome', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [accessibility('monochrome')];
+    component.plugins = [accessibility({mode: 'monochrome'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
@@ -59,7 +59,7 @@ describe('accessibility', () => {
 
   it('should apply colorblind', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [accessibility('colorblind')];
+    component.plugins = [accessibility({mode: 'colorblind'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
@@ -69,7 +69,7 @@ describe('accessibility', () => {
 
   it('should default if supplied with incorrect mode', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [accessibility('ddd')];
+    component.plugins = [accessibility({mode: 'ddd'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;

--- a/packages/angular/projects/cloudinary-library/src/tests/placeholder.spec.ts
+++ b/packages/angular/projects/cloudinary-library/src/tests/placeholder.spec.ts
@@ -25,64 +25,64 @@ describe('placeholder', () => {
     component = fixture.componentInstance;
   });
 
-  it('should apply default', fakeAsync(()=>{
+  it('should apply default', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
     component.plugins = [placeholder()];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
     const img = imgElement.querySelector('img');
-    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.vectorize}/sample`)
+    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.vectorize}/sample`);
   }));
 
-  it('should apply vectorize', fakeAsync(()=> {
+  it('should apply vectorize', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [placeholder('vectorize')];
+    component.plugins = [placeholder({mode: 'vectorize'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
     const img = imgElement.querySelector('img');
-    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.vectorize}/sample`)
+    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.vectorize}/sample`);
   }));
 
-  it('should apply pixelate', fakeAsync(()=>{
+  it('should apply pixelate', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [placeholder('pixelate')];
+    component.plugins = [placeholder({mode: 'pixelate'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
     const img = imgElement.querySelector('img');
-    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.pixelate}/sample`)
+    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.pixelate}/sample`);
   }));
 
-  it('should apply blur', fakeAsync(()=>{
+  it('should apply blur', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [placeholder('blur')];
+    component.plugins = [placeholder({mode: 'blur'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
     const img = imgElement.querySelector('img');
-    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.blur}/sample`)
+    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.blur}/sample`);
   }));
 
-  it('should apply predominant-color', fakeAsync(()=>{
+  it('should apply predominant-color', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [placeholder('predominant-color')];
+    component.plugins = [placeholder({mode: 'predominant-color'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
     const img = imgElement.querySelector('img');
-    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS["predominant-color"]}/sample`)
+    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS['predominant-color']}/sample`);
   }));
 
-  it('should default if supplied with incorrect mode', fakeAsync(()=>{
+  it('should default if supplied with incorrect mode', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [placeholder('ddd')];
+    component.plugins = [placeholder({mode: 'ddd'})];
     fixture.detectChanges();
     tick(0);
     const imgElement: HTMLImageElement = fixture.nativeElement;
     const img = imgElement.querySelector('img');
-    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.vectorize}/sample`)
+    expect(img.src).toBe(`https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.vectorize}/sample`);
   }));
 
   it('should set singleTransparentPixel on error', fakeAsync(() => {

--- a/packages/angular/projects/cloudinary-library/src/tests/responsive.spec.ts
+++ b/packages/angular/projects/cloudinary-library/src/tests/responsive.spec.ts
@@ -42,7 +42,7 @@ describe('responsive', () => {
 
   it('should step by the 100th', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [responsive(100)];
+    component.plugins = [responsive({steps: 100})];
 
     // First resize
     dispatchResize('60px', fixture, 0);
@@ -57,7 +57,7 @@ describe('responsive', () => {
 
   it('should step by breakpoints', fakeAsync(() => {
     component.cldImg = cloudinaryImage;
-    component.plugins = [responsive([800, 1000, 1200, 3000])];
+    component.plugins = [responsive({steps: [800, 1000, 1200, 3000]})];
 
     // First resize
     dispatchResize('60px', fixture, 0);

--- a/packages/html/src/plugins/accessibility.ts
+++ b/packages/html/src/plugins/accessibility.ts
@@ -7,12 +7,11 @@ import {isImage} from "../utils/isImage";
 /**
  * @namespace
  * @description Appends accessibility transformations to the original image.
- * @param mode {AccessibilityMode} The accessibility mode to use. Possible modes: 'darkmode' | 'brightmode' | 'monochrome' | 'colorblind'. Default: 'darkmode'.
  * @return {Plugin}
  * @example <caption>NOTE: The following is in React. For further examples, please see the packages tab</caption>
  * <AdvancedImage cldImg={img} plugins={[accessibility()]}/>
  */
-export function accessibility(mode='darkmode'): Plugin{
+export function accessibility({mode = 'darkmode'}: { mode?: string; }={}): Plugin{
   return accessibilityPlugin.bind(null, mode);
 }
 
@@ -44,4 +43,3 @@ export function accessibilityPlugin(mode: AccessibilityMode, element: HTMLImageE
     pluginCloudinaryImage.effect(ACCESSIBILITY_MODES[mode]);
   }
 }
-

--- a/packages/html/src/plugins/lazyload.ts
+++ b/packages/html/src/plugins/lazyload.ts
@@ -14,12 +14,12 @@ import {isBrowser} from "../utils/isBrowser";
  *     Moreover, when using the plugin make sure to add dimensions, otherwise the images will load with
  *     the size of 0X0, meaning the images will be in the viewport and trigger the lazyload plugin.
  * </caption>
- * <AdvancedImage style={{width: "400px", height: "400px"}}  cldImg={img} plugins=[(lazyload('0px', 0.25))]/>
+ * <AdvancedImage style={{width: "400px", height: "400px"}}  cldImg={img} plugins=[(lazyload({rootMargin: '0px',
+ * threshold: 0.25}))]/>
  */
-export function lazyload(rootMargin?: string, threshold?: number): Plugin{
+export function lazyload({rootMargin='0px', threshold=0.1}:{rootMargin?: string, threshold?: number}={}): Plugin{
   return lazyloadPlugin.bind(null, rootMargin, threshold);
 }
-
 /**
  * @description lazyload plugin
  * @param rootMargin {string} The root element's bounding box before the intersection test is performed. Default: 0px.

--- a/packages/html/src/plugins/placeholder.ts
+++ b/packages/html/src/plugins/placeholder.ts
@@ -13,9 +13,9 @@ import {isImage} from "../utils/isImage";
  * @param mode {PlaceholderMode} The type of placeholder image to display. Possible modes: 'vectorize' | 'pixelate' | 'blur' | 'predominant-color'. Default: 'vectorize'.
  * @return {Plugin}
  * @example <caption>NOTE: The following is in React. For further examples, please see the packages tab</caption>
- * <AdvancedImage cldImg={img} plugins=[(placeholder('blur'))]/>
+ * <AdvancedImage cldImg={img} plugins=[(placeholder({mode: 'blur'}))]/>
  */
-export function placeholder(mode='vectorize'): Plugin{
+export function placeholder({mode='vectorize'}:{mode?: string}={}): Plugin{
   return placeholderPlugin.bind(null, mode);
 }
 

--- a/packages/html/src/plugins/responsive.ts
+++ b/packages/html/src/plugins/responsive.ts
@@ -15,9 +15,9 @@ import {isImage} from "../utils/isImage";
  * | number[] A set of image sizes in pixels.
  * @return {Plugin}
  * @example <caption>NOTE: The following is in React. For further examples, please see the packages tab</caption>
- * <AdvancedImage cldImg={img} plugins=[(responsive(100))] plugins=[(responsive([800, 1000, 1400]))] />
+ * <AdvancedImage cldImg={img} plugins=[(responsive(100))] plugins=[(responsive({steps: [800, 1000, 1400]}))] />
  */
-export function responsive(steps?: number | number[]): Plugin{
+export function responsive({steps}:{steps?: number | number[]}={}): Plugin{
   return responsivePlugin.bind(null, steps);
 }
 

--- a/packages/react/__tests__/accessibility.test.tsx
+++ b/packages/react/__tests__/accessibility.test.tsx
@@ -15,14 +15,14 @@ describe('accessibility', () => {
   });
 
   it('should apply darkmode', function () {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility('darkmode')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility({ mode: 'darkmode' })]} />);
     setTimeout(() => {
       expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/co_black,e_colorize:70/sample"');
     }, 0);// one tick
   });
 
   it('should apply brightmode', function (done) {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility('brightmode')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility({ mode: 'brightmode' })]} />);
     setTimeout(() => {
       expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/co_white,e_colorize:40/sample"');
       done();
@@ -30,7 +30,7 @@ describe('accessibility', () => {
   });
 
   it('should apply monochrome', function (done) {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility('monochrome')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility({ mode: 'monochrome' })]} />);
     setTimeout(() => {
       expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/e_grayscale/sample"');
       done();
@@ -38,7 +38,7 @@ describe('accessibility', () => {
   });
 
   it('should apply colorblind', function (done) {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility('colorblind')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility({ mode: 'colorblind' })]} />);
     setTimeout(() => {
       expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/e_assist_colorblind/sample"');
       done();
@@ -46,7 +46,7 @@ describe('accessibility', () => {
   });
 
   it('should default if supplied with incorrect mode', function (done) {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility('ddd')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[accessibility({ mode: 'ddd' })]} />);
     setTimeout(() => {
       expect(component.html())
         .toBe('<img src="https://res.cloudinary.com/demo/image/upload/co_black,e_colorize:70/sample">');

--- a/packages/react/__tests__/lazyload.test.tsx
+++ b/packages/react/__tests__/lazyload.test.tsx
@@ -34,7 +34,7 @@ describe('lazy-load', () => {
     const elm = document.createElement('img');
     testWithMockedIntersectionObserver((mockIntersectionEvent: ({}) => void) => {
       // @ts-ignore
-      const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[(lazyload('10px', 0.5))]} />);
+      const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[(lazyload({ rootMargin: '10px', threshold: 0.5 }))]} />);
       mockIntersectionEvent([{ isIntersecting: true, target: component.getDOMNode() }]);
       setTimeout(() => {
         expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/sample"');

--- a/packages/react/__tests__/placeholder.test.tsx
+++ b/packages/react/__tests__/placeholder.test.tsx
@@ -27,14 +27,14 @@ describe('placeholder', () => {
   });
 
   it("should apply 'vectorize'", function () {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder('vectorize')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder({ mode: 'vectorize' })]} />);
     setTimeout(() => {
       expect(component.html()).toContain(`src="https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.vectorize}/sample"`);
     }, 0);// one tick
   });
 
   it('should apply pixelate', function (done) {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder('pixelate')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder({ mode: 'pixelate' })]} />);
     setTimeout(() => {
       expect(component.html()).toContain(`src="https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.pixelate}/sample"`);
       done();
@@ -42,7 +42,7 @@ describe('placeholder', () => {
   });
 
   it('should apply blur', function (done) {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder('blur')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder({ mode: 'blur' })]} />);
     setTimeout(() => {
       expect(component.html()).toContain(`src="https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.blur}/sample"`);
       done();
@@ -50,7 +50,7 @@ describe('placeholder', () => {
   });
 
   it('should apply predominant-color', function (done) {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder('predominant-color')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder({ mode: 'predominant-color' })]} />);
     setTimeout(() => {
       expect(component.html()).toContain(`src="https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS['predominant-color']}/sample"`);
       done();
@@ -58,7 +58,7 @@ describe('placeholder', () => {
   });
 
   it('should default if supplied with incorrect mode', function (done) {
-    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder('ddd')]} />);
+    const component = mount(<AdvancedImage cldImg={cloudinaryImage} plugins={[placeholder({ mode: 'ddd' })]} />);
     setTimeout(() => {
       expect(component.html()).toContain(`src="https://res.cloudinary.com/demo/image/upload/${PLACEHOLDER_IMAGE_OPTIONS.vectorize}/sample"`);
       done();

--- a/packages/react/__tests__/responsive.test.tsx
+++ b/packages/react/__tests__/responsive.test.tsx
@@ -45,7 +45,7 @@ describe('responsive', () => {
   it('should step by the 100th', async function () {
     const component = mount(
       <ResponsiveHelper>
-        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive(100)]} />
+        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({ steps: 100 })]} />
       </ResponsiveHelper>);
 
     await clock.tickAsync(0); // one tick
@@ -57,7 +57,7 @@ describe('responsive', () => {
   it('should step by breakpoints', async function () {
     const component = mount(
       <ResponsiveHelper>
-        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive([800, 1000, 1200, 3000])]} />
+        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({ steps: [800, 1000, 1200, 3000] })]} />
       </ResponsiveHelper>);
 
     await clock.tickAsync(0); // one tick
@@ -77,7 +77,7 @@ describe('responsive', () => {
   it('should not resize to larger than provided breakpoints', async function () {
     const component = mount(
       <ResponsiveHelper>
-        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive([800, 1000, 1200, 3000])]} />
+        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({ steps: [800, 1000, 1200, 3000] })]} />
       </ResponsiveHelper>);
 
     await clock.tickAsync(0); // one tick
@@ -90,7 +90,7 @@ describe('responsive', () => {
   it('should handle unordered breakpoints', async function () {
     const component = mount(
       <ResponsiveHelper>
-        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive([1000, 800, 3000, 1200])]} />
+        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({ steps: [1000, 800, 3000, 1200] })]} />
       </ResponsiveHelper>);
 
     await clock.tickAsync(0); // one tick


### PR DESCRIPTION
We want to future-proof our plugins so that we can add a config option as input in the future. 
Our plugins now accept the input as an object rather than parameters 
