### PR TITLE
Fix main module path

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,9 +5,9 @@
   "author": "cloudinary",
   "license": "MIT",
   "repository": "https://github.com/cloudinary/frontend-frameworks",
-  "main": "dist/index.js",
-  "umd:main": "./dist/index.umd.js",
-  "module": "dist/index.esm.js",
+  "main": "index.js",
+  "umd:main": "index.umd.js",
+  "module": "index.esm.js",
   "sideEffects": false,
   "source": "src/index.tsx",
   "engines": {


### PR DESCRIPTION
The main module path is using an nonexistent folder dist

### Pull request for cloudinary/frontend-frameworks
Fix #128 

#### For which package is this PR?
react

#### What does this PR solve?
`package.json` has configured the main module path to a nonexistent `dist` folder, so I've changed to root, where the files are located

#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [x ] Relates to a github issue (link to issue).
