### PR TITLE
Feature/replace build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: node_js
-node_js:
-  - "12"
 addons:
   chrome: stable
-script:
-  - npm run quickstart
-  - npm run test
-
+matrix:
+  include:
+    - node_js: "12"
+      script: npm run quickstart && npm run test
+    - node_js: "14"
+      script: npm run quickstart && npm run test
 notifications:
   email:
     recipients:

--- a/packages/react/__tests__/package.tests.tsx
+++ b/packages/react/__tests__/package.tests.tsx
@@ -2,8 +2,8 @@ import {execSync} from "child_process";
 import fs from 'fs';
 import * as path from "path";
 
-describe('tests for the package', () => {
-  it('works', () => {
+describe('tests for the package output', () => {
+  it('ensures that the pacakge contains the right files', () => {
     execSync('npm run build');
     const dirContents = fs.readdirSync(path.resolve(__dirname, '../dist'));
 

--- a/packages/react/__tests__/package.tests.tsx
+++ b/packages/react/__tests__/package.tests.tsx
@@ -1,0 +1,16 @@
+import {execSync} from "child_process";
+import fs from 'fs';
+import * as path from "path";
+
+describe('tests for the package', () => {
+  it('works', () => {
+    execSync('npm run build');
+    const dirContents = fs.readdirSync(path.resolve(__dirname, '../dist'));
+
+    expect(dirContents.indexOf('index.js')).toBeGreaterThan(-1);
+    expect(dirContents.indexOf('index.umd.js')).toBeGreaterThan(-1);
+    expect(dirContents.indexOf('index.cjs.js')).toBeGreaterThan(-1);
+    expect(dirContents.indexOf('index.d.ts')).toBeGreaterThan(-1);
+    expect(dirContents.indexOf('package.json')).toBeGreaterThan(-1);
+  });
+});

--- a/packages/react/__tests__/package.tests.tsx
+++ b/packages/react/__tests__/package.tests.tsx
@@ -7,10 +7,10 @@ describe('tests for the package output', () => {
     execSync('npm run build');
     const dirContents = fs.readdirSync(path.resolve(__dirname, '../dist'));
 
-    expect(dirContents.indexOf('index.js')).toBeGreaterThan(-1);
-    expect(dirContents.indexOf('index.umd.js')).toBeGreaterThan(-1);
-    expect(dirContents.indexOf('index.cjs.js')).toBeGreaterThan(-1);
-    expect(dirContents.indexOf('index.d.ts')).toBeGreaterThan(-1);
-    expect(dirContents.indexOf('package.json')).toBeGreaterThan(-1);
+    expect(dirContents.includes('index.js')).toBe(true);
+    expect(dirContents.includes('index.umd.js')).toBe(true);
+    expect(dirContents.includes('index.cjs.js')).toBe(true);
+    expect(dirContents.includes('index.d.ts')).toBe(true);
+    expect(dirContents.includes('package.json')).toBe(true);
   });
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -6,14 +6,18 @@
   "license": "MIT",
   "repository": "https://github.com/cloudinary/frontend-frameworks",
   "main": "dist/index.js",
-  "umd:main": "./dist/index.umd.js",
-  "module": "dist/index.esm.js",
+  "publishConfig": {
+    "umd:main": "index.umd.js",
+    "module": "index.esm.js",
+    "types": "index.d.ts"
+  },
   "sideEffects": false,
   "source": "src/index.tsx",
   "engines": {
     "node": ">=10"
   },
   "scripts": {
+    "roll" : "rollup -c",
     "build": "npm run build --prefix ../html && microbundle --format esm,umd,cjs --jsx React.createElement --compress false && cp package.json ./dist",
     "start": "microbundle watch --no-compress --format modern,cjs",
     "test": "jest",
@@ -75,6 +79,10 @@
     ]
   },
   "dependencies": {
-    "@cloudinary/html": "^1.0.1"
+    "@cloudinary/html": "^1.0.1",
+    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-typescript": "^8.3.0",
+    "rollup": "^2.66.1"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,21 +5,16 @@
   "author": "cloudinary",
   "license": "MIT",
   "repository": "https://github.com/cloudinary/frontend-frameworks",
-  "main": "dist/index.js",
-  "publishConfig": {
-    "umd:main": "index.umd.js",
-    "module": "index.esm.js",
-    "types": "index.d.ts"
-  },
+  "main": "index.umd.js",
+  "module": "index.js",
+  "types": "index.d.ts",
   "sideEffects": false,
-  "source": "src/index.tsx",
   "engines": {
     "node": ">=10"
   },
   "scripts": {
     "roll" : "rollup -c",
-    "build": "npm run build --prefix ../html && microbundle --format esm,umd,cjs --jsx React.createElement --compress false && cp package.json ./dist",
-    "start": "microbundle watch --no-compress --format modern,cjs",
+    "build": "npm run build --prefix ../html &&  tsc && rollup -c && cp package.json ./dist",
     "test": "jest",
     "test-coverage": "jest --coverage"
   },
@@ -57,14 +52,20 @@
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-standard": "^4.0.1",
     "gh-pages": "^2.2.0",
-    "microbundle": "^0.13.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.1",
     "ts-jest": "^26.4.4",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5",
+    "@cloudinary/html": "^1.0.1",
+    "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-replace": "^3.0.1",
+    "@rollup/plugin-typescript": "^8.3.0",
+    "rollup": "^2.66.1"
   },
   "jest": {
     "transformIgnorePatterns": [
@@ -79,10 +80,6 @@
     ]
   },
   "dependencies": {
-    "@cloudinary/html": "^1.0.1",
-    "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^13.1.3",
-    "@rollup/plugin-typescript": "^8.3.0",
-    "rollup": "^2.66.1"
+    "@cloudinary/html": "^1.0.1"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,7 +13,6 @@
     "node": ">=10"
   },
   "scripts": {
-    "roll" : "rollup -c",
     "build": "npm run build --prefix ../html &&  tsc && rollup -c && cp package.json ./dist",
     "test": "jest",
     "test-coverage": "jest --coverage"

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -1,26 +1,35 @@
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
-import json from '@rollup/plugin-json';
-// import commonjs from '@rollup/plugin-commonjs';
-// import replace from '@rollup/plugin-replace';
-// import multi from 'rollup-plugin-multi-input';
-// import {version} from './package.json';
+import commonjs from '@rollup/plugin-commonjs';
+import replace from '@rollup/plugin-replace';
+import { version } from './package.json';
 
 export default [
   {
-    input: 'src/index.ts',
+    input: 'src/index.tsx',
     output: [
       {
-        file: 'dist/bundles/umd/base.js',
+        file: 'dist/index.umd.js',
         format: 'umd',
-        name: 'CloudinaryBaseSDK',
+        name: 'CloudinaryBaseSDK'
+      },
+      {
+        file: 'dist/index.js',
+        format: 'esm'
+      },
+      {
+        file: 'dist/index.cjs.js',
+        format: 'cjs'
       }
     ],
     plugins: [
-      json(),
       resolve(),
-      typescript({ target: 'es5' })
-      // commonjs(),
+      replace({
+        PACKAGE_VERSION_INJECTED_DURING_BUILD: version,
+        preventAssignment: false
+      }),
+      typescript({ target: 'es5' }),
+      commonjs()
     ]
   }
 ];

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -1,0 +1,26 @@
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import json from '@rollup/plugin-json';
+// import commonjs from '@rollup/plugin-commonjs';
+// import replace from '@rollup/plugin-replace';
+// import multi from 'rollup-plugin-multi-input';
+// import {version} from './package.json';
+
+export default [
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/bundles/umd/base.js',
+        format: 'umd',
+        name: 'CloudinaryBaseSDK',
+      }
+    ],
+    plugins: [
+      json(),
+      resolve(),
+      typescript({ target: 'es5' })
+      // commonjs(),
+    ]
+  }
+];

--- a/packages/react/src/internal/SDKAnalyticsConstants.ts
+++ b/packages/react/src/internal/SDKAnalyticsConstants.ts
@@ -1,8 +1,7 @@
 import React from 'react'
-import { version } from '../../package.json';
 
 export const SDKAnalyticsConstants = {
-  sdkSemver: version,
+  sdkSemver: 'PACKAGE_VERSION_INJECTED_DURING_BUILD',
   techVersion: React.version,
   sdkCode: 'J'
 };

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "outDir": "dist",
     "module": "esnext",
+    "declarationDir" : "./dist",
     "lib": [
       "dom",
       "esnext"
@@ -27,12 +27,11 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
-    "types": ["jest", "node"]
+    "emitDeclarationOnly": true,
+    "types": ["jest", "node"],
+    "baseUrl": "src"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src/index.tsx"],
   "exclude": [
     "node_modules",
     "dist",


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
React

#### What does this PR solve?
This PR solves the incorrect `main` properties (closes #128, replaces #129)


# Root cause:
The root cause of this issue is the microbundle library which makes heavy assumptions on how the package will look like.
Microbundle connects two different properties into a single use case, the output folder.

Microbundle will decide the output folder based on the `main` property, in our case this is problematic since on build, we want the output to be `./dist/index.js` yet we want the actual value of main in package.json to be `./index.js` 
This contradiction, which cannot seem to be resolved by configuration, makes the library irrelevant for our use case.

# Initial fix:
My initial fix was to replace microbundle with rollup, this surfaced a new problem - type declarations were being generated under `./dist/src` instead of `./dist`.
after some investigation, I reached [this link](https://stackoverflow.com/questions/52121725/maintain-src-folder-structure-when-building-to-dist-folder-with-typescript-3) which describes how an import from outside `src` will cause output directory to contain the `src` directory.

I then realized we're importing the `package.json` file to resolve the version of the package for the SDK analytics.
I replaced the package.json import with a string-replace solution.

I finished up by adding tests that ensure the build generates the desired output.  


# Testing:

Aside from the jest test that was added, I manually verified the package can be installed and types are accurately displayed by the IDE.

#### Final checklist
- [ ] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
- [X] Relates to a github issue (#128, #129).
