### PR TITLE
Responsive Plugin will now respect steps to define max width

### DIFF
--- a/packages/react/__tests__/responsive.test.tsx
+++ b/packages/react/__tests__/responsive.test.tsx
@@ -44,7 +44,7 @@ describe('responsive', () => {
     expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/c_scale,w_251/sample"');
   });
 
-  it.only('Should respect steps and ignore default width of 250', async function () {
+  it('Should respect steps and ignore default width of 250', async function () {
     const component = mount(
       <ResponsiveHelper>
         <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({steps: [10, 20, 30]})]} />

--- a/packages/react/__tests__/responsive.test.tsx
+++ b/packages/react/__tests__/responsive.test.tsx
@@ -31,16 +31,31 @@ describe('responsive', () => {
     expect(el.clientWidth).toBe(250);
   });
 
-  it('Should respect single step and ignore default width of 250', async function () {
+
+  it('Should respect single step and ignore default width of 250 (When Step < Width)', async function () {
+    const component = mount(
+      <ResponsiveHelper>
+        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({steps: 100})]} />
+      </ResponsiveHelper>);
+
+    clock.tick(100); // timeout for debounce
+
+    // Output is exactly 300 due to internal rounding: ROUND_UP(CONTAINER / STEP) * STEP
+    // When STEP < CONTAINER, output is always a multiplication of STEP
+    expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/c_scale,w_300/sample"');
+  });
+
+
+  it('Should respect single step and ignore default width of 250 (When Step > Width)', async function () {
     const component = mount(
       <ResponsiveHelper>
         <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({steps: 251})]} />
       </ResponsiveHelper>);
 
-    window.dispatchEvent(new Event('resize'));
     clock.tick(100); // timeout for debounce
 
-    // Output is exactly 251, no matter what size the parent container here (Due to steps being defined as 251)
+    // Output is exactly 251 due to internal rounding: ROUND_UP(CONTAINER / STEP) * STEP
+    // When STEP > CONTAINER, output is always STEP.
     expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/c_scale,w_251/sample"');
   });
 
@@ -50,7 +65,6 @@ describe('responsive', () => {
         <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({steps: [10, 20, 30]})]} />
       </ResponsiveHelper>);
 
-    window.dispatchEvent(new Event('resize'));
     clock.tick(100); // timeout for debounce
 
     // Output is closest number to parentElement, never exceeding the width of the max step )

--- a/packages/react/__tests__/responsive.test.tsx
+++ b/packages/react/__tests__/responsive.test.tsx
@@ -31,6 +31,32 @@ describe('responsive', () => {
     expect(el.clientWidth).toBe(250);
   });
 
+  it('Should respect single step and ignore default width of 250', async function () {
+    const component = mount(
+      <ResponsiveHelper>
+        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({steps: 251})]} />
+      </ResponsiveHelper>);
+
+    window.dispatchEvent(new Event('resize'));
+    clock.tick(100); // timeout for debounce
+
+    // Output is exactly 251, no matter what size the parent container here (Due to steps being defined as 251)
+    expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/c_scale,w_251/sample"');
+  });
+
+  it.only('Should respect steps and ignore default width of 250', async function () {
+    const component = mount(
+      <ResponsiveHelper>
+        <AdvancedImage cldImg={cloudinaryImage} plugins={[responsive({steps: [10, 20, 30]})]} />
+      </ResponsiveHelper>);
+
+    window.dispatchEvent(new Event('resize'));
+    clock.tick(100); // timeout for debounce
+
+    // Output is closest number to parentElement, never exceeding the width of the max step )
+    expect(component.html()).toContain('src="https://res.cloudinary.com/demo/image/upload/c_scale,w_30/sample"');
+  });
+
   it('should update container width on window resize', function () {
     const component = mount(
       <ResponsiveHelper>


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks
---

#### For which package is this PR?

React, Angular

#### What does this PR solve?
This PR solves the default behavour of the responsive plugin.

- Before this PR, the first render of the responsive plugin would render an image with the width of the parent container.

- After this PR is merged, the responsive plugin will always respect the steps to define the width of the image on an initial render. 


#### Final checklist
- [X] Implementation is aligned to Spec.
- [X] Tests - Add proper tests to the added code.
- [X] Relates to a github issue #93 
