### PR TITLE
fix svelte build requirements

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -6,6 +6,7 @@
   "umd": "./index.umd.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",
+  "type": "module",
   "sideEffects": false,
   "repository": "https://github.com/cloudinary/frontend-frameworks",
   "scripts": {

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -1,13 +1,13 @@
 /**
  * Import and export all needed types
  */
-export { HtmlImageLayer } from './layers/htmlImageLayer';
-export { HtmlVideoLayer } from './layers/htmlVideoLayer';
-export {responsive} from './plugins/responsive';
-export {lazyload} from './plugins/lazyload';
-export {accessibility} from './plugins/accessibility';
-export {placeholder} from './plugins/placeholder';
-export {isBrowser} from './utils/isBrowser';
-export {serverSideSrc} from './utils/serverSideSrc';
-export {Plugins, VideoSources, PictureSources} from './types';
-export {cancelCurrentlyRunningPlugins} from './utils/cancelCurrentlyRunningPlugins';
+export { HtmlImageLayer } from './layers/htmlImageLayer.js';
+export { HtmlVideoLayer } from './layers/htmlVideoLayer.js';
+export {responsive} from './plugins/responsive.js';
+export {lazyload} from './plugins/lazyload.js';
+export {accessibility} from './plugins/accessibility.js';
+export {placeholder} from './plugins/placeholder.js';
+export {isBrowser} from './utils/isBrowser.js';
+export {serverSideSrc} from './utils/serverSideSrc.js';
+export {Plugins, VideoSources, PictureSources} from './types.js';
+export {cancelCurrentlyRunningPlugins} from './utils/cancelCurrentlyRunningPlugins.js';

--- a/packages/html/src/layers/htmlImageLayer.ts
+++ b/packages/html/src/layers/htmlImageLayer.ts
@@ -1,7 +1,7 @@
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
-import {Plugins, HtmlPluginState, AnalyticsOptions} from '../types'
+import {Plugins, HtmlPluginState, AnalyticsOptions} from '../types.js'
 import cloneDeep from 'lodash.clonedeep';
-import {render} from '../utils/render';
+import {render} from '../utils/render.js';
 
 export class HtmlImageLayer{
   private imgElement: any;

--- a/packages/html/src/layers/htmlVideoLayer.ts
+++ b/packages/html/src/layers/htmlVideoLayer.ts
@@ -1,8 +1,8 @@
-import {Plugins, HtmlPluginState, VideoSources, VideoType} from '../types'
+import {Plugins, HtmlPluginState, VideoSources, VideoType} from '../types.js'
 import cloneDeep from 'lodash.clonedeep'
 import {CloudinaryVideo} from "@cloudinary/url-gen";
-import {render} from '../utils/render';
-import {VIDEO_MIME_TYPES} from "../utils/internalConstants";
+import {render} from '../utils/render.js';
+import {VIDEO_MIME_TYPES} from "../utils/internalConstants.js";
 
 const ANALYTICS_DELIMITER = '?_a=';
 

--- a/packages/html/src/plugins/accessibility.ts
+++ b/packages/html/src/plugins/accessibility.ts
@@ -1,8 +1,8 @@
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
-import {Plugin, AccessibilityMode, HtmlPluginState} from "../types";
-import {ACCESSIBILITY_MODES} from '../utils/internalConstants';
-import {isBrowser} from "../utils/isBrowser";
-import {isImage} from "../utils/isImage";
+import {Plugin, AccessibilityMode, HtmlPluginState} from "../types.js";
+import {ACCESSIBILITY_MODES} from '../utils/internalConstants.js';
+import {isBrowser} from "../utils/isBrowser.js";
+import {isImage} from "../utils/isImage.js";
 
 /**
  * @namespace

--- a/packages/html/src/plugins/lazyload.ts
+++ b/packages/html/src/plugins/lazyload.ts
@@ -1,6 +1,6 @@
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
-import {Plugin, HtmlPluginState} from '../types'
-import {isBrowser} from "../utils/isBrowser";
+import {Plugin, HtmlPluginState} from '../types.js'
+import {isBrowser} from "../utils/isBrowser.js";
 
 /**
  * @namespace

--- a/packages/html/src/plugins/placeholder.ts
+++ b/packages/html/src/plugins/placeholder.ts
@@ -1,11 +1,11 @@
 import cloneDeep from 'lodash.clonedeep'
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
 import {Plugin, HtmlPluginState} from "../types";
-import {PLACEHOLDER_IMAGE_OPTIONS, singleTransparentPixel} from '../utils/internalConstants';
-import {PlaceholderMode} from '../types';
-import {isBrowser} from "../utils/isBrowser";
+import {PLACEHOLDER_IMAGE_OPTIONS, singleTransparentPixel} from '../utils/internalConstants.js';
+import {PlaceholderMode} from '../types.js';
+import {isBrowser} from "../utils/isBrowser.js";
 import {Action} from "@cloudinary/url-gen/internal/Action";
-import {isImage} from "../utils/isImage";
+import {isImage} from "../utils/isImage.js";
 
 /**
  * @namespace

--- a/packages/html/src/plugins/responsive.ts
+++ b/packages/html/src/plugins/responsive.ts
@@ -1,11 +1,11 @@
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
-import {Plugin, HtmlPluginState} from "../types";
+import {Plugin, HtmlPluginState} from "../types.js";
 import {scale} from "@cloudinary/url-gen/actions/resize";
 import debounce from 'lodash.debounce';
-import {isNum} from '../utils/isNum';
-import {isBrowser} from "../utils/isBrowser";
+import {isNum} from '../utils/isNum.js';
+import {isBrowser} from "../utils/isBrowser.js";
 import {Action} from "@cloudinary/url-gen/internal/Action";
-import {isImage} from "../utils/isImage";
+import {isImage} from "../utils/isImage.js";
 
 /**
  * @namespace

--- a/packages/html/src/utils/cancelCurrentlyRunningPlugins.ts
+++ b/packages/html/src/utils/cancelCurrentlyRunningPlugins.ts
@@ -1,4 +1,4 @@
-import {HtmlPluginState} from '../types'
+import {HtmlPluginState} from '../types.js'
 
 /**
  * Cancels currently running plugins. This is called from unmount or update

--- a/packages/html/src/utils/internalConstants.ts
+++ b/packages/html/src/utils/internalConstants.ts
@@ -1,5 +1,4 @@
-import {colorize, grayscale, assistColorBlind} from "@cloudinary/url-gen/actions/effect";
-import {vectorize, pixelate, blur} from "@cloudinary/url-gen/actions/effect";
+import {colorize, grayscale, assistColorBlind, vectorize, pixelate, blur} from "@cloudinary/url-gen/actions/effect";
 import {Transformation} from "@cloudinary/url-gen/transformation/Transformation";
 import {pad, crop, fill} from "@cloudinary/url-gen/actions/resize";
 import {Background} from "@cloudinary/url-gen/qualifiers/background";

--- a/packages/html/src/utils/render.ts
+++ b/packages/html/src/utils/render.ts
@@ -1,4 +1,4 @@
-import {Plugins, HtmlPluginState} from '../types'
+import {Plugins, HtmlPluginState} from '../types.js'
 import {CloudinaryVideo, CloudinaryImage} from "@cloudinary/url-gen";
 
 /**

--- a/packages/html/src/utils/serverSideSrc.ts
+++ b/packages/html/src/utils/serverSideSrc.ts
@@ -6,7 +6,7 @@
  */
 import {CloudinaryImage} from "@cloudinary/url-gen/assets/CloudinaryImage";
 import cloneDeep from 'lodash.clonedeep'
-import {Plugins} from "../types";
+import {Plugins} from "../types.js";
 
 export  function serverSideSrc(plugins?: Plugins, serverCloudinaryImage?: CloudinaryImage): string {
   const clonedServerCloudinaryImage  = cloneDeep(serverCloudinaryImage);


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
HTML

#### What does this PR solve?
We're fixing svelte build requirements.
1. need to have .js extensions in order for svelte builds to find the path. 
2. according to svelte we need to have type="module" when exporting an esm otherwise the build fails. 

See #101 for more info