### PR TITLE
remove production mode

### DIFF
--- a/packages/angular/projects/cloudinary-library/src/lib/cloudinary.module.ts
+++ b/packages/angular/projects/cloudinary-library/src/lib/cloudinary.module.ts
@@ -2,11 +2,6 @@ import { NgModule, enableProdMode } from '@angular/core';
 import { CloudinaryImageComponent } from './cloudinary-image.component';
 import { CloudinaryVideoComponent } from './cloudinary-video.component';
 
-/**
- * Enables production mode. Added to remove
- * ng reflects from dom.
- */
-enableProdMode();
 
 @NgModule({
   imports: [


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
cloudinary/ng

#### What does this PR solve?
Removes production mode for Angular. 

Note that when using plugins we'll the plugins reflected in the dom. That being said users can easily remove if they use production mode-
<img width="766" alt="Screen Shot 2022-04-03 at 9 48 26" src="https://user-images.githubusercontent.com/28888221/161415671-93822d35-1236-42ac-a0e9-3d63e82cb7ea.png">



