### PR TITLE
Add angular 12 as peer dependency

### DIFF
--- a/packages/angular/projects/cloudinary-library/package.json
+++ b/packages/angular/projects/cloudinary-library/package.json
@@ -3,8 +3,8 @@
   "version": "1.3.0",
   "repository": "https://github.com/cloudinary/frontend-frameworks",
   "peerDependencies": {
-    "@angular/common": "^10.0.0 || ^11.0.0",
-    "@angular/core": "^10.0.0 || ^11.0.0"
+    "@angular/common": "^10.0.0 || ^11.0.0 || ^12.0.0",
+    "@angular/core": "^10.0.0 || ^11.0.0 || ^12.0.0"
   },
   "devDependencies": {
     "@cloudinary/url-gen": "^1.4.0"


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
Angular

#### What does this PR solve?
The pr should add `@angular/common` and `@angular/core` version 12 as valid peer dependencies.

According to https://angular.io/guide/releases#deprecation-practices all functionalities available in version 10, should also be available in version 12, unless you use some stuff which has been flagged as deprecated in version 8 and 9. Please feel free to decline the pr if this should be the case
