### PR TITLE
Fix incorrect responsive behaviour with SSR responsive

### DIFF
--- a/packages/html/src/plugins/accessibility.ts
+++ b/packages/html/src/plugins/accessibility.ts
@@ -41,5 +41,7 @@ export function accessibilityPlugin(mode: AccessibilityMode, element: HTMLImageE
     });
   }else{
     pluginCloudinaryImage.effect(ACCESSIBILITY_MODES[mode]);
+    // @ts-ignore
+    return true;
   }
 }

--- a/packages/html/src/plugins/placeholder.ts
+++ b/packages/html/src/plugins/placeholder.ts
@@ -51,11 +51,26 @@ function placeholderPlugin(mode: PlaceholderMode, element: HTMLImageElement, plu
     // in SSR, we copy the transformations of the clone to the user provided CloudinaryImage
     // We return here, since we don't have HTML elements to work with.
     pluginCloudinaryImage.transformation = placeholderClonedImage.transformation;
-    return;
+
+    // @ts-ignore
+    // TODO remove TS Ignore
+    return true;
   }
 
   // Client side rendering, if an image was not provided we don't perform any action
   if(!isImage(element)) return;
+
+  // For the cloned placeholder image, we remove the responsive action.
+  // There's no need to load e_pixelate,w_{responsive} beacuse that image is temporary as-is
+  // and it just causes another image to load.
+
+  // This also means that the de-facto way to use responsive in SSR is WITH placeholder.
+  // This also means that the user must provide dimensions for the responsive plugin on the img tag.
+  placeholderClonedImage.transformation.actions.forEach((action, index) => {
+    if (action instanceof Action && action.getActionTag() === 'responsive') {
+      delete placeholderClonedImage.transformation.actions[index];
+    }
+  });
 
   // Set the SRC of the imageElement to the URL of the placeholder Image
   element.src = placeholderClonedImage.toURL();

--- a/packages/html/src/plugins/responsive.ts
+++ b/packages/html/src/plugins/responsive.ts
@@ -28,7 +28,9 @@ export function responsive({steps}:{steps?: number | number[]}={}): Plugin{
  * @param htmlPluginState {HtmlPluginState} holds cleanup callbacks and event subscriptions
  */
 function responsivePlugin(steps?: number | number[], element?:HTMLImageElement, responsiveImage?: CloudinaryImage, htmlPluginState?: HtmlPluginState): Promise<void | string> {
-  if(!isBrowser()) return;
+  // @ts-ignore
+  // TODO remove TS Ignore
+  if(!isBrowser()) return true;
 
   if(!isImage(element)) return;
 
@@ -40,7 +42,7 @@ function responsivePlugin(steps?: number | number[], element?:HTMLImageElement, 
 
     // Use a tagged generic action that can be later searched and replaced.
     responsiveImage.addAction(new Action().setActionTag('responsive'));
-    // Immediately run the resize plugin, ensuring that first render gets an responive image.
+    // Immediately run the resize plugin, ensuring that first render gets an responsive image.
     onResize(steps, element, responsiveImage);
 
     let resizeRef: any;


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
HTML

#### What does this PR solve?
This PR fixes several problems with SSR.

1. Remove incorrect plugin stops (returning null) in SSR, such as accessibility and responsive.
2. In Responsive SSR, the default behaviour was changed to "Do nothing, NOOP" (Instead of returning the original unscaled image)
3. In placeholder plugin, the plugin will not remove from the placeholder any resize attributes provided by the responsive plugin - this makes sense in both SSR and client side rendering as it avoids reloading a scaled down placeholder image.



#### Final checklist
- [X] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
