### PR TITLE
fix: guard html image layer analytics options

### DIFF
--- a/packages/html/src/layers/htmlImageLayer.ts
+++ b/packages/html/src/layers/htmlImageLayer.ts
@@ -15,11 +15,11 @@ export class HtmlImageLayer{
         .then(()=>{ // when resolved updates the src
           this.htmlPluginState.pluginEventSubscription.forEach(fn=>{fn()});
             this.imgElement.setAttribute('src', pluginCloudinaryImage.toURL({
-                trackedAnalytics: {
+                ...analyticsOptions && {trackedAnalytics: {
                     sdkCode: analyticsOptions.sdkCode,
                     sdkSemver: analyticsOptions.sdkSemver,
                     techVersion: analyticsOptions.techVersion,
-                }
+                }}
             }));
         });
   }
@@ -35,11 +35,11 @@ export class HtmlImageLayer{
     render(this.imgElement, pluginCloudinaryImage, plugins, this.htmlPluginState)
         .then(()=>{
           this.imgElement.setAttribute('src', pluginCloudinaryImage.toURL({
-              trackedAnalytics: {
+            ...analyticsOptions && {trackedAnalytics: {
                   sdkCode: analyticsOptions.sdkCode,
                   sdkSemver: analyticsOptions.sdkSemver,
                   techVersion: analyticsOptions.techVersion,
-              }
+              }}
           }));
         });
   }


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
@cloudinary/html

#### What does this PR solve?
Fixes html image layer errors when analytics is not provided. 


#### Final checklist
- [x] Implementation is aligned to Spec.
- [-] Tests - Add proper tests to the added code.
- [x] Relates to a github issue: https://cloudinary.atlassian.net/browse/SNI-7149
