### PR TITLE
Fix/vue ssr analytics token

### DIFF
--- a/packages/vue3/src/components/AdvancedImage.vue
+++ b/packages/vue3/src/components/AdvancedImage.vue
@@ -37,7 +37,7 @@ const props = defineProps<ImgProps>();
 const imageRef = ref(null);
 let htmlLayerInstance;
 
-const getSsrSrc = () => serverSideSrc(props.plugins, props.cldImg);
+const getSsrSrc = () => serverSideSrc(props.plugins, props.cldImg, SDKAnalyticsConstants);
 
 /**
  * On mount, creates a new HTMLLayer instance and initializes with ref to img element,

--- a/packages/vue3/src/components/AdvancedImage.vue
+++ b/packages/vue3/src/components/AdvancedImage.vue
@@ -1,6 +1,6 @@
 <template>
   <img v-if="isBrowser()" ref="imageRef" />
-  <img v-else src="{{getSsrSrc()}}" />
+  <img v-else :src="getSsrSrc()" />
 </template>
 
 <script setup lang="ts">

--- a/packages/vue3/tests/unit/analytics-ssr.spec.ts
+++ b/packages/vue3/tests/unit/analytics-ssr.spec.ts
@@ -1,8 +1,12 @@
+/**
+ * @jest-environment node
+ */
 import { AdvancedImage } from "../../src";
 import { CloudinaryImage } from "@cloudinary/url-gen/assets/CloudinaryImage";
-import { mount } from "@vue/test-utils";
-import { testIf, waitTicks } from "./utils";
+import { createSSRApp } from "vue";
+import { renderToString } from "vue/server-renderer";
 import { SDKAnalyticsConstants } from "../../src/internal/SDKAnalyticsConstants";
+import { testIf } from "./utils";
 
 const cloudinaryImage = new CloudinaryImage("sample", { cloudName: "demo" });
 
@@ -15,12 +19,15 @@ describe("analytics", () => {
       SDKAnalyticsConstants.sdkSemver = "1.0.0";
       SDKAnalyticsConstants.techVersion = "10.2.5";
 
-      const component = mount(AdvancedImage, {
-        props: { cldImg: cloudinaryImage },
+      const app = createSSRApp({
+        template: '<AdvancedImage :cldImg="cldImg" />',
+        data: () => ({
+          cldImg: cloudinaryImage,
+        }),
+        components: { AdvancedImage },
       });
-      await waitTicks(1);
-
-      expect(component.html()).toMatch(
+      const html = await renderToString(app);
+      expect(html).toMatch(
         '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=AL'
       );
     }
@@ -30,12 +37,15 @@ describe("analytics", () => {
     process.env.VUE3_TEST_ENV === "DIST",
     "creates an img with analytics using dist",
     async () => {
-      const component = mount(AdvancedImage, {
-        props: { cldImg: cloudinaryImage },
+      const app = createSSRApp({
+        template: '<AdvancedImage :cldImg="cldImg" />',
+        data: () => ({
+          cldImg: cloudinaryImage,
+        }),
+        components: { AdvancedImage },
       });
-      await waitTicks(1);
-
-      expect(component.html()).toMatch(
+      const html = await renderToString(app);
+      expect(html).toMatch(
         '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=AL'
       );
     }

--- a/packages/vue3/tests/unit/utils.ts
+++ b/packages/vue3/tests/unit/utils.ts
@@ -11,3 +11,12 @@ export const waitTicks = async (ticks: number) => {
     await nextTick();
   }
 };
+
+/**
+ * Run test if condition is true
+ * Otherwise act as passing test
+ * @param condition
+ * @param args
+ */
+export const testIf = (condition: boolean, ...args: [string, () => void]) =>
+    condition ? test(...args) : {};


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
@cloudinary/vue3

#### What does this PR solve?
1. The `AdvancedImage` didn't work in SSR. There was an issue in how the url was bounded to the `img` tag.
2. Use the same analytics token in both SSR and CSR in order to prevent unnecessary requests from the browser
3. Added tests for the analytics token in SSR

#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
