### PR TITLE
fix: VideoProps to extend video tag attributes

### DIFF
--- a/packages/react/src/AdvancedVideo.tsx
+++ b/packages/react/src/AdvancedVideo.tsx
@@ -1,4 +1,4 @@
-import React, { Component, createRef, EventHandler, MutableRefObject, SyntheticEvent } from 'react';
+import React, { Component, createRef, EventHandler, HTMLAttributes, MutableRefObject, SyntheticEvent } from 'react';
 import { CloudinaryVideo } from '@cloudinary/url-gen';
 
 import {
@@ -10,7 +10,7 @@ import {
 
 type ReactEventHandler<T = Element> = EventHandler<SyntheticEvent<T>>;
 
-interface VideoProps {
+interface VideoProps extends HTMLAttributes<HTMLVideoElement>{
   cldVid: CloudinaryVideo,
   plugins?: Plugins,
   sources?: VideoSources,
@@ -143,10 +143,10 @@ class AdvancedVideo extends Component <VideoProps> {
       plugins,
       sources,
       innerRef,
-      ...videoEvents // Assume any other props are for the base element
+      ...videoAttrs // Assume any other props are for the base element
     } = this.props;
 
-    return <video {...videoEvents} ref={this.attachRef} />
+    return <video {...videoAttrs} ref={this.attachRef} />
   }
 }
 


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
@cloudinary/react

#### What does this PR solve?
change the type of `AdvancedVideo` props so they will include any valid `video` tag attributes


#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
