### PR TITLE
chore: override sanitize-html version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "foodoc": {
       "handlebars": {
         "minimist": "1.2.6"
-      }
+      },
+      "sanitize-html": "2.9.0"
     }
   }
 }


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
frontend-frameworks-monorepo 

#### What does this PR solve?
Override the version of `sanitize-html`. Since `foodoc` isn't maintain anymore, we have to override it manually

#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
