### PR TITLE
chore: move docs packages to dev dependencies

### DIFF
--- a/e2e-tests/react-test-app/package.json
+++ b/e2e-tests/react-test-app/package.json
@@ -5,17 +5,8 @@
   "dependencies": {
     "@cloudinary/url-gen": "^1.0.0-beta.5",
     "@cloudinary/react": "file:cloudinary-react.tgz",
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
-    "@types/jest": "^26.0.15",
-    "@types/node": "^12.0.0",
-    "@types/react": "^17.0.0",
-    "@types/react-dom": "^17.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-scripts": "4.0.3",
-    "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"
   },
   "scripts": {
@@ -44,6 +35,15 @@
     ]
   },
   "devDependencies": {
-    "del-cli": "^3.0.1"
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0",
+    "@testing-library/user-event": "^12.1.10",
+    "@types/jest": "^26.0.15",
+    "@types/node": "^12.0.0",
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
+    "del-cli": "^3.0.1",
+    "react-scripts": "4.0.3",
+    "typescript": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,16 +10,14 @@
     "start:docs": "live-server --open=public/docs",
     "update:urlgen": "npm install @cloudinary/url-gen@latest --prefix packages/html && npm install @cloudinary/url-gen@latest --prefix packages/react && npm install @cloudinary/url-gen@latest --prefix packages/vue && npm install @cloudinary/url-gen@latest --prefix packages/angular && npm install @cloudinary/url-gen@latest --prefix packages/angular/projects/cloudinary-library"
   },
-  "dependencies": {
+  "devDependencies": {
     "better-docs": "2.3.2",
     "foodoc": "0.0.9",
     "jsdoc": "3.6.4",
     "jsdoc-plugin-typescript": "2.0.5",
-    "typedoc": "^0.17.8"
-  },
-  "devDependencies": {
     "lerna": "^4.0.0",
-    "replace-in-file": "^6.2.0"
+    "replace-in-file": "^6.2.0",
+    "typedoc": "^0.17.8"
   },
   "overrides": {
     "foodoc": {


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
All packages

#### What does this PR solve?
- Moved all `devDependencies` incorrectly listed as `dependencies` which should fix all our security issues reported by Snyk
- No versions of packages were changed here

#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).

<img width="924" alt="image" src="https://user-images.githubusercontent.com/104944154/217559832-ca360ad5-7b37-4e8b-85fe-95bbe91e8a6e.png">

