### PR TITLE
fix: cleanup html layer on component unmount

### DIFF
--- a/packages/html/__tests__/HtmlImageLayer.test.ts
+++ b/packages/html/__tests__/HtmlImageLayer.test.ts
@@ -3,8 +3,10 @@ import {HtmlImageLayer} from "../src";
 import {BaseAnalyticsOptions} from "../src/types";
 import {responsive} from "../src/plugins/responsive";
 import {placeholder} from "../src/plugins/placeholder";
-import {lazyload} from "../src/plugins/lazyload";
 import {accessibility} from "../src/plugins/accessibility";
+import {PluginResponse} from "../types";
+import {cancelCurrentlyRunningPlugins} from "../src/utils/cancelCurrentlyRunningPlugins";
+import * as process from "process";
 
 jest.useFakeTimers();
 
@@ -50,5 +52,56 @@ describe('HtmlImageLayer tests', function () {
         new HtmlImageLayer(img, cldImage, [accessibility()], sdkAnalyticsTokens);
         await flushPromises();
         expect(img.src).toEqualAnalyticsToken('AXAABABD');
+    });
+
+    it('should set image src twice if HtmlImageLayer instance won\'t be destroyed', async function () {
+        const img = document.createElement('img');
+        const pluginsState: any = {
+            cleanupCallbacks: []
+        };
+        const spy = jest.spyOn(img, 'setAttribute');
+        const dummyFailingPlugin = (): Promise<PluginResponse> => {
+            return new Promise((resolve) => {
+                pluginsState.cleanupCallbacks.push(() => {
+                    resolve('canceled')
+                })
+            })
+        }
+        const dummyLazyLoadPlugin = (): Promise<PluginResponse> => {
+            return new Promise((resolve) => {
+                resolve({lazyload: true});
+            })
+        }
+        new HtmlImageLayer(img, cldImage, [dummyFailingPlugin]);
+        new HtmlImageLayer(img, cldImage, [dummyLazyLoadPlugin]);
+        cancelCurrentlyRunningPlugins(pluginsState);
+        await flushPromises();
+        expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should set image src only once if HtmlImageLayer instance will be destroyed', async function () {
+        const img = document.createElement('img');
+        const pluginsState: any = {
+            cleanupCallbacks: []
+        };
+        const spy = jest.spyOn(img, 'setAttribute');
+        const dummyFailingPlugin = (): Promise<PluginResponse> => {
+            return new Promise((resolve) => {
+                pluginsState.cleanupCallbacks.push(() => {
+                    resolve('canceled')
+                })
+            })
+        }
+        const dummyLazyLoadPlugin = (): Promise<PluginResponse> => {
+            return new Promise((resolve) => {
+                resolve({lazyload: true});
+            })
+        }
+        const instance1 = new HtmlImageLayer(img, cldImage, [dummyFailingPlugin]);
+        new HtmlImageLayer(img, cldImage, [dummyLazyLoadPlugin]);
+        cancelCurrentlyRunningPlugins(pluginsState);
+        instance1.destroy();
+        await flushPromises();
+        expect(spy).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/html/__tests__/HtmlImageLayer.test.ts
+++ b/packages/html/__tests__/HtmlImageLayer.test.ts
@@ -6,7 +6,6 @@ import {placeholder} from "../src/plugins/placeholder";
 import {accessibility} from "../src/plugins/accessibility";
 import {PluginResponse} from "../types";
 import {cancelCurrentlyRunningPlugins} from "../src/utils/cancelCurrentlyRunningPlugins";
-import * as process from "process";
 
 jest.useFakeTimers();
 
@@ -54,24 +53,20 @@ describe('HtmlImageLayer tests', function () {
         expect(img.src).toEqualAnalyticsToken('AXAABABD');
     });
 
-    it('should set image src twice if HtmlImageLayer instance won\'t be destroyed', async function () {
+    it('should set image src twice if HtmlImageLayer instance won\'t be unmounted', async function () {
         const img = document.createElement('img');
         const pluginsState: any = {
             cleanupCallbacks: []
         };
         const spy = jest.spyOn(img, 'setAttribute');
-        const dummyFailingPlugin = (): Promise<PluginResponse> => {
-            return new Promise((resolve) => {
-                pluginsState.cleanupCallbacks.push(() => {
-                    resolve('canceled')
-                })
+        const dummyFailingPlugin = (): Promise<PluginResponse> => new Promise((resolve) => {
+            pluginsState.cleanupCallbacks.push(() => {
+                resolve('canceled')
             })
-        }
-        const dummyLazyLoadPlugin = (): Promise<PluginResponse> => {
-            return new Promise((resolve) => {
-                resolve({lazyload: true});
-            })
-        }
+        });
+        const dummyLazyLoadPlugin = (): Promise<PluginResponse> => new Promise((resolve) => {
+            resolve({lazyload: true});
+        });
         new HtmlImageLayer(img, cldImage, [dummyFailingPlugin]);
         new HtmlImageLayer(img, cldImage, [dummyLazyLoadPlugin]);
         cancelCurrentlyRunningPlugins(pluginsState);
@@ -79,28 +74,24 @@ describe('HtmlImageLayer tests', function () {
         expect(spy).toHaveBeenCalledTimes(2);
     });
 
-    it('should set image src only once if HtmlImageLayer instance will be destroyed', async function () {
+    it('should set image src only once if HtmlImageLayer instance will be unmounted', async function () {
         const img = document.createElement('img');
         const pluginsState: any = {
             cleanupCallbacks: []
         };
         const spy = jest.spyOn(img, 'setAttribute');
-        const dummyFailingPlugin = (): Promise<PluginResponse> => {
-            return new Promise((resolve) => {
-                pluginsState.cleanupCallbacks.push(() => {
-                    resolve('canceled')
-                })
+        const dummyFailingPlugin = (): Promise<PluginResponse> => new Promise((resolve) => {
+            pluginsState.cleanupCallbacks.push(() => {
+                resolve('canceled')
             })
-        }
-        const dummyLazyLoadPlugin = (): Promise<PluginResponse> => {
-            return new Promise((resolve) => {
-                resolve({lazyload: true});
-            })
-        }
+        });
+        const dummyLazyLoadPlugin = (): Promise<PluginResponse> => new Promise((resolve) => {
+            resolve({lazyload: true});
+        });
         const instance1 = new HtmlImageLayer(img, cldImage, [dummyFailingPlugin]);
         new HtmlImageLayer(img, cldImage, [dummyLazyLoadPlugin]);
         cancelCurrentlyRunningPlugins(pluginsState);
-        instance1.destroy();
+        instance1.unmount();
         await flushPromises();
         expect(spy).toHaveBeenCalledTimes(1);
     });

--- a/packages/html/src/layers/htmlImageLayer.ts
+++ b/packages/html/src/layers/htmlImageLayer.ts
@@ -6,7 +6,7 @@ import {getAnalyticsOptions} from "../utils/analytics";
 
 export class HtmlImageLayer{
   private imgElement: any;
-  private destroyed = false;
+  private isMounted = true;
   htmlPluginState: HtmlPluginState;
   constructor(element: HTMLImageElement | null, userCloudinaryImage: CloudinaryImage, plugins?: Plugins, baseAnalyticsOptions?: BaseAnalyticsOptions){
     this.imgElement = element;
@@ -15,7 +15,7 @@ export class HtmlImageLayer{
 
     render(element, pluginCloudinaryImage, plugins, this.htmlPluginState, baseAnalyticsOptions)
         .then((pluginResponse)=>{ // when resolved updates the src
-          if (this.destroyed) {
+          if (!this.isMounted) {
               return;
           }
           this.htmlPluginState.pluginEventSubscription.forEach(fn=>{fn()});
@@ -34,14 +34,14 @@ export class HtmlImageLayer{
     const pluginCloudinaryImage  = cloneDeep(userCloudinaryImage);
     render(this.imgElement, pluginCloudinaryImage, plugins, this.htmlPluginState)
         .then((pluginResponse)=>{
-            if (this.destroyed) {
+            if (!this.isMounted) {
                 return;
             }
             const featuredAnalyticsOptions = getAnalyticsOptions(baseAnalyticsOptions, pluginResponse);
             this.imgElement.setAttribute('src', pluginCloudinaryImage.toURL(featuredAnalyticsOptions));
         });
   }
-  destroy() {
-      this.destroyed = true;
+  unmount() {
+      this.isMounted = false;
   }
 }

--- a/packages/html/src/layers/htmlImageLayer.ts
+++ b/packages/html/src/layers/htmlImageLayer.ts
@@ -6,6 +6,7 @@ import {getAnalyticsOptions} from "../utils/analytics";
 
 export class HtmlImageLayer{
   private imgElement: any;
+  private destroyed = false;
   htmlPluginState: HtmlPluginState;
   constructor(element: HTMLImageElement | null, userCloudinaryImage: CloudinaryImage, plugins?: Plugins, baseAnalyticsOptions?: BaseAnalyticsOptions){
     this.imgElement = element;
@@ -14,6 +15,9 @@ export class HtmlImageLayer{
 
     render(element, pluginCloudinaryImage, plugins, this.htmlPluginState, baseAnalyticsOptions)
         .then((pluginResponse)=>{ // when resolved updates the src
+          if (this.destroyed) {
+              return;
+          }
           this.htmlPluginState.pluginEventSubscription.forEach(fn=>{fn()});
           const analyticsOptions = getAnalyticsOptions(baseAnalyticsOptions, pluginResponse);
           this.imgElement.setAttribute('src', pluginCloudinaryImage.toURL(analyticsOptions));
@@ -30,8 +34,14 @@ export class HtmlImageLayer{
     const pluginCloudinaryImage  = cloneDeep(userCloudinaryImage);
     render(this.imgElement, pluginCloudinaryImage, plugins, this.htmlPluginState)
         .then((pluginResponse)=>{
+            if (this.destroyed) {
+                return;
+            }
             const featuredAnalyticsOptions = getAnalyticsOptions(baseAnalyticsOptions, pluginResponse);
             this.imgElement.setAttribute('src', pluginCloudinaryImage.toURL(featuredAnalyticsOptions));
         });
+  }
+  destroy() {
+      this.destroyed = true;
   }
 }

--- a/packages/react/src/AdvancedImage.tsx
+++ b/packages/react/src/AdvancedImage.tsx
@@ -102,7 +102,7 @@ class AdvancedImage extends React.Component <ImgProps> {
   componentWillUnmount() {
     // Safely cancel running events on unmount.
     cancelCurrentlyRunningPlugins(this.htmlLayerInstance.htmlPluginState);
-    this.htmlLayerInstance.destroy();
+    this.htmlLayerInstance.unmount();
   }
 
   render() {

--- a/packages/react/src/AdvancedImage.tsx
+++ b/packages/react/src/AdvancedImage.tsx
@@ -97,11 +97,12 @@ class AdvancedImage extends React.Component <ImgProps> {
   }
 
   /**
-   * On unmount, we cancel the currently running plugins.
+   * On unmount, we cancel the currently running plugins, and destroy the html layer instance
    */
   componentWillUnmount() {
     // Safely cancel running events on unmount.
     cancelCurrentlyRunningPlugins(this.htmlLayerInstance.htmlPluginState);
+    this.htmlLayerInstance.destroy();
   }
 
   render() {


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
`@cloudinary/html`
`@cloudinary/react`

#### What does this PR solve?
Add a fix to ensure the html layer is still in use when trying to update the `img` element.

In React 18 in `<StrictMode />`, the `lazyload` plugin does not work as expected. The issue is that since the plugin's promise is being resolved after a new instance of `HtmlImageLayer` is created, the previous `HtmlImageLayer` is updating the `img` element with the `src` which is not the expected behavior. 



#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
