### PR TITLE
fix: fix placeholder plugin token

### DIFF
--- a/packages/html/__tests__/HtmlImageLayer.test.ts
+++ b/packages/html/__tests__/HtmlImageLayer.test.ts
@@ -16,7 +16,7 @@ const sdkAnalyticsTokens: BaseAnalyticsOptions = {
 }
 
 const flushPromises = async () => {
-    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(10);
     await Promise.resolve();
 }
 

--- a/packages/html/__tests__/HtmlImageLayer.test.ts
+++ b/packages/html/__tests__/HtmlImageLayer.test.ts
@@ -114,7 +114,8 @@ describe('HtmlImageLayer tests', function () {
         new HtmlImageLayer(img, cldImage, [placeholder()], sdkAnalyticsTokens);
         expect(imgSrcSpy).toHaveBeenCalledTimes(1);
         // test that the initial src is set to a token contains last character "B" which is the character of placeholder plugin
-        expect(imgSrcSpy.mock.calls[0][0]).toEqualAnalyticsToken('AXAABABB');
+        const imgSrcSpyAnalyticsToken = imgSrcSpy.mock.calls[0][0];
+        expect(imgSrcSpyAnalyticsToken).toEqualAnalyticsToken('AXAABABB');
         // trigger load event in order to resolve the 1st promise of the placeholder plugin
         img.dispatchEvent(new Event('load'));
         await flushPromises();

--- a/packages/html/src/plugins/placeholder.ts
+++ b/packages/html/src/plugins/placeholder.ts
@@ -26,7 +26,7 @@ export function placeholder({mode='vectorize'}:{mode?: string}={}): Plugin{
  * @param element {HTMLImageElement} The image element.
  * @param pluginCloudinaryImage {CloudinaryImage}
  * @param htmlPluginState {htmlPluginState} Holds cleanup callbacks and event subscriptions.
- * @param analyticsOptions {BaseAnalyticsOptions} analytics options for the url to be created
+ * @param baseAnalyticsOptions {BaseAnalyticsOptions} analytics options for the url to be created
  */
 function placeholderPlugin(mode: PlaceholderMode, element: HTMLImageElement, pluginCloudinaryImage: CloudinaryImage, htmlPluginState: HtmlPluginState, baseAnalyticsOptions?: BaseAnalyticsOptions): Promise<PluginResponse> | boolean {
   // @ts-ignore
@@ -104,12 +104,12 @@ function placeholderPlugin(mode: PlaceholderMode, element: HTMLImageElement, plu
       const largeImage = new Image();
       largeImage.src = pluginCloudinaryImage.toURL(analyticsOptions);
       largeImage.onload = () => {
-        resolve();
+        resolve({placeholder: true});
       };
 
       // image does not load, resolve
       largeImage.onerror = () => {
-        resolve();
+        resolve({placeholder: true});
       };
     });
   });


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
@cloudinary/html

#### What does this PR solve?
- Fix an issue where `placeholder` plugin causing extra request when used with analytics token
- Add a test to verify the token is the same in both phases of the rendering flow


#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
