### PR TITLE
fix: return last plugin response

### DIFF
--- a/packages/html/src/utils/render.ts
+++ b/packages/html/src/utils/render.ts
@@ -19,5 +19,7 @@ export async function render(element: HTMLImageElement | HTMLVideoElement, plugi
             break;
         }
     }
-    return response
+    if (response !== 'canceled') {
+        return response;
+    }
 }

--- a/packages/html/src/utils/render.ts
+++ b/packages/html/src/utils/render.ts
@@ -1,4 +1,4 @@
-import {Plugins, HtmlPluginState, BaseAnalyticsOptions} from '../types'
+import {Plugins, HtmlPluginState, BaseAnalyticsOptions, PluginResponse} from '../types'
 import {CloudinaryVideo, CloudinaryImage} from "@cloudinary/url-gen";
 
 /**
@@ -11,13 +11,13 @@ import {CloudinaryVideo, CloudinaryImage} from "@cloudinary/url-gen";
  * @param analyticsOptions {BaseAnalyticsOptions} analytics options for the url to be created
  */
 export async function render(element: HTMLImageElement | HTMLVideoElement, pluginCloudinaryAsset: CloudinaryImage | CloudinaryVideo, plugins: Plugins, pluginState: HtmlPluginState, analyticsOptions?: BaseAnalyticsOptions) {
-    if(plugins === undefined) return;
-    for(let i = 0; i < plugins.length; i++){
-        const response = await plugins[i](element, pluginCloudinaryAsset, pluginState, analyticsOptions);
-        if(response === 'canceled'){
+    if (plugins === undefined) return;
+    let response: PluginResponse;
+    for (let i = 0; i < plugins.length; i++) {
+        response = await plugins[i](element, pluginCloudinaryAsset, pluginState, analyticsOptions);
+        if (response === 'canceled') {
             break;
-        } else {
-            return response
         }
     }
+    return response
 }


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
`@cloudinary/html`

#### What does this PR solve?
Instead of returning the promise result inside the loop, returning the promise of the last plugin, which solve the issue when multiple plugins working together ends up in a wrong order of requests


#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
