### PR TITLE
feat: add intersection observer root option

### DIFF
--- a/packages/html/src/plugins/lazyload.ts
+++ b/packages/html/src/plugins/lazyload.ts
@@ -9,6 +9,7 @@ type IntersectionObserverInitRoot = IntersectionObserverInit['root'];
  * @description Loads an image once it is in a certain margin in the viewport. This includes vertical and horizontal scrolling.
  * @param rootMargin {string} The root element's bounding box before the intersection test is performed. Default: 0px.
  * @param threshold {number} The percentage of the image's visibility at which point the image should load. Default: 0.1 (10%).
+ * @param root {number} The element that is used as the viewport for checking visibility of the target. Must be the ancestor of the target. Defaults to the browser viewport if not specified or if null.
  * @return {Plugin}
  * @example
  * <caption>


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
`@cloudinary/html`

#### What does this PR solve?
Add an option to provide `root` option to lazyload plugins which will be passed to the `IntersectionObserver`


#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
