### PR TITLE
Make responsive plugin aware of placeholder to avoid duplicated requests

### DIFF
--- a/packages/html/__tests__/HtmlImageLayer.test.ts
+++ b/packages/html/__tests__/HtmlImageLayer.test.ts
@@ -96,7 +96,7 @@ describe('HtmlImageLayer tests', function () {
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
-    it('should verifiy no unneeded request with placeholder plugin', async function () {
+    it('should verify no unneeded request with placeholder plugin', async function () {
         const OriginalImage = Image;
         // mocking Image constructor in order to simulate firing 'load' event
         jest.spyOn(global, "Image").mockImplementation(() => {
@@ -128,7 +128,7 @@ describe('HtmlImageLayer tests', function () {
         expect(imgSetAttributeSpy.mock.calls[0][1]).toEqualAnalyticsToken('BAXAABABB');
     });
 
-    it('should verifiy no responsive image request is fired with placeholder plugin', async function () {
+    it('should not request responsive image before placeholder image is loaded', async function () {
         // Set mock screen width
         Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 640 })
 
@@ -142,7 +142,6 @@ describe('HtmlImageLayer tests', function () {
         const img = document.createElement('img');
         parentElement.append(img);
         new HtmlImageLayer(img, cldImage, [responsive({steps: 200}),placeholder()], sdkAnalyticsTokens);
-
         await flushPromises();
         
         // the initial src is set to a placeholder image

--- a/packages/html/src/plugins/placeholder.ts
+++ b/packages/html/src/plugins/placeholder.ts
@@ -28,8 +28,6 @@ export function placeholder({mode='vectorize'}:{mode?: string}={}): Plugin{
  * @param htmlPluginState {htmlPluginState} Holds cleanup callbacks and event subscriptions.
  * @param baseAnalyticsOptions {BaseAnalyticsOptions} analytics options for the url to be created
  */
-// TODO: Optionally we might want to hold of with rendering
-//       Maybe there is something in the responsive plugin already that should be moved here too?
 function placeholderPlugin(mode: PlaceholderMode, element: HTMLImageElement, pluginCloudinaryImage: CloudinaryImage, htmlPluginState: HtmlPluginState, baseAnalyticsOptions?: BaseAnalyticsOptions, plugins?: Plugin[]): Promise<PluginResponse> | boolean {
   // @ts-ignore
   // If we're using an invalid mode, we default to vectorize

--- a/packages/html/src/plugins/responsive.ts
+++ b/packages/html/src/plugins/responsive.ts
@@ -31,6 +31,7 @@ export function responsive({steps}:{steps?: number | number[]}={}): Plugin{
  * @param analyticsOptions {BaseAnalyticsOptions} analytics options for the url to be created
  */
 function responsivePlugin(steps?: number | number[], element?:HTMLImageElement, responsiveImage?: CloudinaryImage, htmlPluginState?: HtmlPluginState, baseAnalyticsOptions?: BaseAnalyticsOptions, plugins?: Plugin[]): Promise<PluginResponse> | boolean {
+
   if(!isBrowser()) return true;
 
   if(!isImage(element)) return;
@@ -74,7 +75,6 @@ function responsivePlugin(steps?: number | number[], element?:HTMLImageElement, 
  * @param analyticsOptions {AnalyticsOptions} analytics options for the url to be created
  */
 function onResize(steps?: number | number[], element?:HTMLImageElement, responsiveImage?: CloudinaryImage, analyticsOptions?: AnalyticsOptions){
-    
   updateByContainerWidth(steps, element, responsiveImage);
   element.src = responsiveImage.toURL(analyticsOptions);
 }

--- a/packages/html/src/utils/isPluginUsed.ts
+++ b/packages/html/src/utils/isPluginUsed.ts
@@ -1,0 +1,18 @@
+import { Plugin } from "../types";
+
+const initialPlugins = {
+  accessibility: false,
+  lazyload: false,
+  placeholder: false,
+  responsive: false,
+};
+
+const getPluginType = (name: string) => name.replace('bound ', '').replace('Plugin', '');
+
+export const isPluginUsed = (plugins: Plugin[], pluginType: keyof typeof initialPlugins) => {
+  const usedPlugins = plugins.reduce(
+    (used, { name }) => ({ ...used, [getPluginType(name)]: true }),
+    initialPlugins
+  );
+  return usedPlugins[pluginType];
+};

--- a/packages/html/src/utils/isPluginUsed.ts
+++ b/packages/html/src/utils/isPluginUsed.ts
@@ -9,7 +9,7 @@ const initialPlugins = {
 
 const getPluginType = (name: string) => name.replace('bound ', '').replace('Plugin', '');
 
-export const isPluginUsed = (plugins: Plugin[], pluginType: keyof typeof initialPlugins) => {
+export const isPluginUsed = (plugins: Plugin[] = [], pluginType: keyof typeof initialPlugins) => {
   const usedPlugins = plugins.reduce(
     (used, { name }) => ({ ...used, [getPluginType(name)]: true }),
     initialPlugins

--- a/packages/html/src/utils/render.ts
+++ b/packages/html/src/utils/render.ts
@@ -1,4 +1,3 @@
-import { lazyload } from 'plugins/lazyload';
 import {Plugins, HtmlPluginState, BaseAnalyticsOptions, PluginResponse} from '../types'
 import {CloudinaryVideo, CloudinaryImage} from "@cloudinary/url-gen";
 
@@ -15,23 +14,9 @@ export async function render(element: HTMLImageElement | HTMLVideoElement, plugi
     if (plugins === undefined) return;
     let response: PluginResponse;
     for (let i = 0; i < plugins.length; i++) {
-        // TODO: We have to pass all plugins to each plugin (so that each can determine what to do)
-        // 1. Pass plugins as a fifth parameter below (after analyticsOptions)
-        // 
-        // 2. Inside each plugin we can use `name` property of the plugin functions to see what was added
-        // 
-        // Example given the plugins look like below: 
-        // const plugins = [lazyload(), responsive()]
-        // Then if you console log plugins[0].name you should get 'bound lazyloadPlugin'
-        // plugins[0].name === 'bound lazyloadPlugin'
-        const pluginResponse = await plugins[i](element, pluginCloudinaryAsset, pluginState, analyticsOptions, plugins);
+        response = await plugins[i](element, pluginCloudinaryAsset, pluginState, analyticsOptions, plugins);
         if (response === 'canceled') {
             break;
-        }
-        if(typeof pluginResponse === 'object') {
-            response = {...response, ...pluginResponse};
-        } else {
-            response = pluginResponse
         }
     }
     if (response !== 'canceled') {

--- a/packages/vue/tests/unit/AdvancedImage.spec.ts
+++ b/packages/vue/tests/unit/AdvancedImage.spec.ts
@@ -80,8 +80,6 @@ describe("AdvancedImage.vue", () => {
 
     // trigger AdvancedImage.onUpdate
     await component.setProps({
-      cldImg: cloudinaryImage,
-      plugins: [mock],
       style: "color: blue;",
     });
 

--- a/playground/html/index.html
+++ b/playground/html/index.html
@@ -4,15 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@Cloudinary/html Playground</title>
-    <style>
-        img {
-           width: 100%;
-        }
-    </style>
   </head>
   <body>
-    <h1>Test Environment</h1>  
-    <div id="app" style="width:500px"></div>
+    <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/playground/html/src/main.ts
+++ b/playground/html/src/main.ts
@@ -1,14 +1,13 @@
 import {CloudinaryImage} from "@cloudinary/url-gen";
 import {HtmlImageLayer} from "@cloudinary/html";
-import {responsive,placeholder} from "@cloudinary/html";
+import {responsive} from "@cloudinary/html";
 
 const app = document.querySelector<HTMLDivElement>('#app');
 if (app) {
     const img = document.createElement('img');
     const cldImg = new CloudinaryImage('sample', {cloudName: 'demo'});
-    console.debug("img.URL: ", cldImg.toURL());
     app.append(img);
-    new HtmlImageLayer(img, cldImg, [responsive({steps: 200}),placeholder()], {
+    new HtmlImageLayer(img, cldImg, [responsive({steps: [100]})], {
         sdkCode: 'X',
         sdkSemver: '1.0.0',
         techVersion: '2.0.0'


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?

* `@cloudinary/html`

#### What does this PR solve?

* When responsive plugin is combined with placeholder it will fire additional request even before the placeholder image is fetched, see below before and after. 
* The first request is fired with different analytics than the second one and I'm not sure what is the expected one but we get rid of the first one so the second request (previously third) stays the same

##### Before

<img width="929" alt="Screenshot 2023-11-28 at 15 48 56" src="https://github.com/cloudinary/frontend-frameworks/assets/104944154/c69a16b2-3c3e-42f3-b7b4-4ba7e2d817c6">

##### After

<img width="929" alt="Screenshot 2023-11-28 at 15 49 16" src="https://github.com/cloudinary/frontend-frameworks/assets/104944154/e51efcaf-0f58-4546-916d-18d0c15edf71">


#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
