### PR TITLE
fix: ensure unobserve is a function

### DIFF
--- a/packages/html/src/plugins/lazyload.ts
+++ b/packages/html/src/plugins/lazyload.ts
@@ -66,7 +66,7 @@ function detectIntersection(el: HTMLImageElement | HTMLVideoElement, onIntersect
     if (!isIntersectionObserverSupported()) {
       // Return if there's no need or possibility to detect intersection
       onIntersect();
-      return;
+      return () => {};
     }
     // Detect intersection with given element using IntersectionObserver
     const observer = new IntersectionObserver(


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
html

#### What does this PR solve?
fix an issue where `intersectionObserver` is not existed (for example in tests) the `unObserve` is not a function

#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
