### PR TITLE
feat: add useFetchFormat prop in react sdk

### DIFF
--- a/packages/html/__tests__/HtmlVideoLayer.test.ts
+++ b/packages/html/__tests__/HtmlVideoLayer.test.ts
@@ -1,0 +1,62 @@
+import { CloudinaryVideo } from "@cloudinary/url-gen";
+import { videoCodec } from "@cloudinary/url-gen/actions/transcode";
+import { auto, theora, vp9 } from '@cloudinary/url-gen/qualifiers/videoCodec';
+
+import { HtmlVideoLayer } from "../src";
+
+jest.useFakeTimers();
+
+const flushPromises = async () => {
+    jest.advanceTimersByTime(10);
+    await Promise.resolve();
+}
+
+describe('HtmlVideoLayer tests', function () {
+    const cldVideo = new CloudinaryVideo('sample.mp4', {cloudName: 'demo'}, { analytics: false });
+    
+    it('should not append extension when useFetchFormat video option is used with default sources', async function() {
+        const video = document.createElement('video', {});
+        new HtmlVideoLayer(video, cldVideo, undefined, [], {}, undefined, { useFetchFormat: true });
+        await flushPromises();
+        
+        expect(video.childNodes[0].src).toBe('https://res.cloudinary.com/demo/video/upload/f_webm/sample.mp4');
+        expect(video.childNodes[0].type).toBe('video/webm');
+
+        expect(video.childNodes[1].src).toBe('https://res.cloudinary.com/demo/video/upload/f_mp4/sample.mp4');
+        expect(video.childNodes[1].type).toBe('video/mp4');
+
+        expect(video.childNodes[2].src).toBe('https://res.cloudinary.com/demo/video/upload/f_ogv/sample.mp4');
+        expect(video.childNodes[2].type).toBe('video/ogg');
+    });    
+
+    it('should not append extension when useFetchFormat video option is used', async function() {
+        const sources = [
+        {
+            type: 'mp4',
+            codecs: ['avc1.4d002a'],
+            transcode: videoCodec(auto())
+        },
+        {
+            type: 'webm',
+            codecs: ['vp8', 'vorbis'],
+            transcode: videoCodec(vp9())
+        },
+        {
+            type: 'ogv',
+            codecs: ['theora'],
+            transcode: [videoCodec(theora())],
+        }];
+        const video = document.createElement('video', {});
+        new HtmlVideoLayer(video, cldVideo, sources, [], {}, undefined, { useFetchFormat: true });
+        await flushPromises();
+
+        expect(video.childNodes[0].src).toBe('https://res.cloudinary.com/demo/video/upload/vc_auto/f_mp4/sample.mp4');
+        expect(video.childNodes[0].type).toBe('video/mp4; codecs=avc1.4d002a');
+
+        expect(video.childNodes[1].src).toBe('https://res.cloudinary.com/demo/video/upload/vc_vp9/f_webm/sample.mp4');
+        expect(video.childNodes[1].type).toBe('video/webm; codecs=vp8, vorbis');
+
+        expect(video.childNodes[2].src).toBe('https://res.cloudinary.com/demo/video/upload/vc_theora/f_ogv/sample.mp4');
+        expect(video.childNodes[2].type).toBe('video/ogg; codecs=theora');
+    });
+});

--- a/packages/html/src/types.ts
+++ b/packages/html/src/types.ts
@@ -33,3 +33,7 @@ type FeatureNames = Pick<ITrackedPropertiesThroughAnalytics, 'accessibility' | '
 export type Features = Partial<Record<keyof FeatureNames, boolean>>
 
 export type VideoPoster = CloudinaryImage | 'auto';
+
+export type VideoOptions = {
+  useFetchFormat?: boolean;
+}

--- a/packages/react/__tests__/AdvancedVideo.test.tsx
+++ b/packages/react/__tests__/AdvancedVideo.test.tsx
@@ -2,11 +2,12 @@ import { AdvancedVideo } from '../src';
 import { CloudinaryImage, CloudinaryVideo } from '@cloudinary/url-gen';
 import { mount } from 'enzyme';
 import React from 'react';
-import { auto, vp9 } from '@cloudinary/url-gen/qualifiers/videoCodec';
+import { auto, theora, vp9 } from '@cloudinary/url-gen/qualifiers/videoCodec';
 import { videoCodec } from '@cloudinary/url-gen/actions/transcode';
 
 const cloudinaryImage = new CloudinaryImage('sample', { cloudName: 'demo' }, { analytics: false });
 const cloudinaryVideo = new CloudinaryVideo('sample', { cloudName: 'demo' }, { analytics: false });
+const cloudinaryVideoWithExtension = new CloudinaryVideo('sample.mp4', { cloudName: 'demo' }, { analytics: false });
 const cloudinaryVideoWithAnalytics = new CloudinaryVideo('sample', { cloudName: 'demo' }, { analytics: true });
 
 describe('AdvancedVideo', () => {
@@ -55,6 +56,36 @@ describe('AdvancedVideo', () => {
         '<video>' +
         '<source src="https://res.cloudinary.com/demo/video/upload/vc_auto/sample.mp4" type="video/mp4; codecs=vp8, vorbis">' +
         '<source src="https://res.cloudinary.com/demo/video/upload/vc_vp9/sample.webm" type="video/webm; codecs=avc1.4D401E, mp4a.40.2"></video>');
+      done();
+    }, 0);// one tick
+  });
+
+  it('should render video with input sources when using useFetchFormat', function (done) {
+    const sources = [
+      {
+        type: 'mp4',
+        codecs: ['vp8', 'vorbis'],
+        transcode: videoCodec(auto())
+      },
+      {
+        type: 'webm',
+        codecs: ['avc1.4D401E', 'mp4a.40.2'],
+        transcode: videoCodec(vp9())
+      },
+      {
+        type: 'ogv',
+        codecs: ['theora'],
+        transcode: videoCodec(theora())
+      }];
+
+    const component = mount(<AdvancedVideo cldVid={cloudinaryVideoWithExtension} sources={sources} useFetchFormat />);
+
+    setTimeout(() => {
+      expect(component.html()).toContain(
+        '<video>' +
+        '<source src="https://res.cloudinary.com/demo/video/upload/vc_auto/f_mp4/sample.mp4" type="video/mp4; codecs=vp8, vorbis">' +
+        '<source src="https://res.cloudinary.com/demo/video/upload/vc_vp9/f_webm/sample.mp4" type="video/webm; codecs=avc1.4D401E, mp4a.40.2">' + 
+        '<source src="https://res.cloudinary.com/demo/video/upload/vc_theora/f_ogv/sample.mp4" type="video/ogg; codecs=theora"></video>');
       done();
     }, 0);// one tick
   });

--- a/packages/react/src/AdvancedVideo.tsx
+++ b/packages/react/src/AdvancedVideo.tsx
@@ -17,6 +17,7 @@ interface VideoProps extends HTMLAttributes<HTMLVideoElement>{
   plugins?: Plugins,
   sources?: VideoSources,
   innerRef?: ((instance: any) => void) | MutableRefObject<unknown> | null
+  useFetchFormat?: boolean,
 
   // supported video attributes
   controls?: boolean
@@ -87,7 +88,10 @@ class AdvancedVideo extends Component <VideoProps> {
       this.props.sources,
       this.props.plugins,
       this.getVideoAttributes(),
-      this.props.cldPoster
+      this.props.cldPoster,
+      { 
+        useFetchFormat: this.props.useFetchFormat
+      }
     )
   }
 
@@ -153,6 +157,7 @@ class AdvancedVideo extends Component <VideoProps> {
       plugins,
       sources,
       innerRef,
+      useFetchFormat,
       ...videoAttrs // Assume any other props are for the base element
     } = this.props;
 


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
- @cloudinary/html
- @cloudinary/react

#### What does this PR solve?
- Adds a new prop and an option (in html package) to `useFetchFormat`
- When this option is enabled: 
  - the extension is not added in the video sources
  - the delivery format is set by `type`  

#### Tested in the playground 

##### With default sources

<img width="1649" alt="image" src="https://github.com/cloudinary/frontend-frameworks/assets/104944154/ffbd1dd2-dfe5-4c27-bceb-37cc197e4608">

##### With provided sources

<img width="1644" alt="image" src="https://github.com/cloudinary/frontend-frameworks/assets/104944154/6486ae8f-46e8-4cf3-8fb1-abd3daddb562">

#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
