### PR TITLE
fix: bump url-gen and update analytics related tests

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -33,7 +33,7 @@
     "@angular/cli": "~12.2.16",
     "@angular/compiler-cli": "~12.2.16",
     "@cloudinary/html": "^1.11.2",
-    "@cloudinary/url-gen": "^1.10.1",
+    "@cloudinary/url-gen": "^1.16.0",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",

--- a/packages/angular/projects/cloudinary-library/package.json
+++ b/packages/angular/projects/cloudinary-library/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@angular/common": "~12.2.16",
     "@angular/core": "~12.2.16",
-    "@cloudinary/url-gen": "^1.10.1"
+    "@cloudinary/url-gen": "^1.16.0"
   },
   "dependencies": {
     "@cloudinary/html": "^1.11.2"

--- a/packages/angular/projects/cloudinary-library/src/tests/analytics.spec.ts
+++ b/packages/angular/projects/cloudinary-library/src/tests/analytics.spec.ts
@@ -33,6 +33,6 @@ describe('analytics', () => {
     const imgElement: HTMLImageElement = fixture.nativeElement;
     const img = imgElement.querySelector('img');
 
-    expect(img.src).toBe('https://res.cloudinary.com/demo/image/upload/sample?_a=BAKAABDS0');
+    expect(img.src).toBe('https://res.cloudinary.com/demo/image/upload/sample?_a=DAKAABDSZAA0');
   }));
 });

--- a/packages/html/__tests__/HtmlImageLayer.test.ts
+++ b/packages/html/__tests__/HtmlImageLayer.test.ts
@@ -27,7 +27,7 @@ describe('HtmlImageLayer tests', function () {
         const img = document.createElement('img');
         new HtmlImageLayer(img, cldImage, [], sdkAnalyticsTokens);
         await flushPromises();
-        expect(img.src).toEqualAnalyticsToken('BAXAABAB0');
+        expect(img.src).toEqualAnalyticsToken('DAXAABABZAA0');
     });
 
     it('should use feature flag for responsive plugin', async function () {
@@ -36,21 +36,21 @@ describe('HtmlImageLayer tests', function () {
         parentElement.append(img);
         new HtmlImageLayer(img, cldImage, [responsive({steps: [100]})], sdkAnalyticsTokens);
         await flushPromises();
-        expect(img.src).toEqualAnalyticsToken('BAXAABABA');
+        expect(img.src).toEqualAnalyticsToken('DAXAABABZAAA');
     });
 
     it('should use feature flag for placeholder plugin', async function () {
         const img = document.createElement('img');
         new HtmlImageLayer(img, cldImage, [placeholder()], sdkAnalyticsTokens);
         await flushPromises();
-        expect(img.src).toEqualAnalyticsToken('BAXAABABB');
+        expect(img.src).toEqualAnalyticsToken('DAXAABABZAAB');
     });
 
     it('should use feature flag for accessibility plugin', async function () {
         const img = document.createElement('img');
         new HtmlImageLayer(img, cldImage, [accessibility()], sdkAnalyticsTokens);
         await flushPromises();
-        expect(img.src).toEqualAnalyticsToken('BAXAABABD');
+        expect(img.src).toEqualAnalyticsToken('DAXAABABZAAD');
     });
 
     it('should set image src twice if HtmlImageLayer instance won\'t be unmounted', async function () {
@@ -115,7 +115,7 @@ describe('HtmlImageLayer tests', function () {
         expect(imgSrcSpy).toHaveBeenCalledTimes(1);
         // test that the initial src is set to a token contains last character "B" which is the character of placeholder plugin
         const imgSrcSpyAnalyticsToken = imgSrcSpy.mock.calls[0][0];
-        expect(imgSrcSpyAnalyticsToken).toEqualAnalyticsToken('BAXAABABB');
+        expect(imgSrcSpyAnalyticsToken).toEqualAnalyticsToken('DAXAABABZAAB');
         // trigger load event in order to resolve the 1st promise of the placeholder plugin
         img.dispatchEvent(new Event('load'));
         await flushPromises();
@@ -125,7 +125,7 @@ describe('HtmlImageLayer tests', function () {
         await flushPromises();
         expect(imgSetAttributeSpy).toHaveBeenCalledTimes(1);
         // test that the src which set by HtmlImageLayer contains last character "B" which is the character of placeholder plugin
-        expect(imgSetAttributeSpy.mock.calls[0][1]).toEqualAnalyticsToken('BAXAABABB');
+        expect(imgSetAttributeSpy.mock.calls[0][1]).toEqualAnalyticsToken('DAXAABABZAAB');
     });
 
     it('should not request responsive image before placeholder image is loaded', async function () {
@@ -145,7 +145,7 @@ describe('HtmlImageLayer tests', function () {
         await flushPromises();
         
         // the initial src is set to a placeholder image
-        expect(img.src).toBe("https://res.cloudinary.com/demo/image/upload/e_vectorize/q_auto/f_svg/sample?_a=BAXAABABB");
+        expect(img.src).toBe("https://res.cloudinary.com/demo/image/upload/e_vectorize/q_auto/f_svg/sample?_a=DAXAABABZAAB");
         await flushPromises();
         
         // simulate placeholder image loaded
@@ -153,6 +153,6 @@ describe('HtmlImageLayer tests', function () {
         await flushPromises();
         
         // the second image that is loaded should have the responsive width set
-        expect(img.src).toBe("https://res.cloudinary.com/demo/image/upload/c_scale,w_800/sample?_a=BAXAABABB");
+        expect(img.src).toBe("https://res.cloudinary.com/demo/image/upload/c_scale,w_800/sample?_a=DAXAABABZAAB");
     });
 });

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-typescript": "^7.14.5",
-    "@cloudinary/url-gen": "^1.10.1",
+    "@cloudinary/url-gen": "^1.16.0",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@types/jest": "^29.4.0",

--- a/packages/html/src/types.ts
+++ b/packages/html/src/types.ts
@@ -28,7 +28,7 @@ export type BaseAnalyticsOptions = {sdkSemver: string, techVersion: string, sdkC
 
 export type AnalyticsOptions = Parameters<CloudinaryImage['toURL']>[0];
 
-type FeatureNames = Omit<ITrackedPropertiesThroughAnalytics, 'sdkCode' | 'sdkSemver' | 'techVersion' | 'product'>
+type FeatureNames = Pick<ITrackedPropertiesThroughAnalytics, 'accessibility' | 'lazyload' | 'responsive'| 'placeholder'>;
 
 export type Features = Partial<Record<keyof FeatureNames, boolean>>
 

--- a/packages/react/__tests__/analytics-ssr.test.tsx
+++ b/packages/react/__tests__/analytics-ssr.test.tsx
@@ -27,7 +27,7 @@ describe('ssr analytics', () => {
     )
     setTimeout(() => {
       expect(ElementImageHtml).toContain(
-        'https://res.cloudinary.com/demo/image/upload/sample?_a=BAJAABDS0'
+        'https://res.cloudinary.com/demo/image/upload/sample?_a=DAJAABDSZAA0'
       )
       done()
     }, 0) // one tick

--- a/packages/react/__tests__/analytics.test.tsx
+++ b/packages/react/__tests__/analytics.test.tsx
@@ -21,7 +21,7 @@ describe('analytics', () => {
   it('creates an img with analytics', function (done) {
     const component = mount(<AdvancedImage cldImg={cloudinaryImage} />);
     setTimeout(() => {
-      expect(component.html()).toEqual('<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=BAJAABDS0">');
+      expect(component.html()).toEqual('<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=DAJAABDSZAA0">');
       done();
     }, 0);// one tick
   });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,7 @@
     "@babel/preset-env": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
     "@cloudinary/html": "^1.0.1",
-    "@cloudinary/url-gen": "^1.10.1",
+    "@cloudinary/url-gen": "^1.16.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.1.3",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@cloudinary/html": "^1.0.1",
-    "@cloudinary/url-gen": "^1.10.1",
+    "@cloudinary/url-gen": "^1.16.0",
     "@rollup/plugin-replace": "^4.0.0",
     "@sinonjs/fake-timers": "^9.1.2",
     "@types/jest": "^27.0.1",

--- a/packages/vue/tests/unit/analytics-ssr.spec.ts
+++ b/packages/vue/tests/unit/analytics-ssr.spec.ts
@@ -28,7 +28,7 @@ describe("analytics", () => {
       });
       const html = await renderToString(app);
       expect(html).toMatch(
-        '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=BALAABDS0'
+        '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=DALAABDSZAA0'
       );
     }
   );
@@ -46,7 +46,7 @@ describe("analytics", () => {
       });
       const html = await renderToString(app);
       expect(html).toMatch(
-        '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=BALFJtDL0'
+        '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=DALFJtDLZAA0'
       );
     }
   );

--- a/packages/vue/tests/unit/analytics.spec.ts
+++ b/packages/vue/tests/unit/analytics.spec.ts
@@ -21,7 +21,7 @@ describe("analytics", () => {
       await waitTicks(1);
 
       expect(component.html()).toMatch(
-        '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=BALAABDS0'
+        '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=DALAABDSZAA0'
       );
     }
   );
@@ -36,7 +36,7 @@ describe("analytics", () => {
       await waitTicks(1);
 
       expect(component.html()).toMatch(
-        '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=BALFJtDL0'
+        '<img src="https://res.cloudinary.com/demo/image/upload/sample?_a=DALFJtDLZAA0'
       );
     }
   );


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
- @cloudinary/react
- @cloudinary/angular
- @cloudinary/vue
- @cloudinary/html

#### What does this PR solve?
- Bumped version of `url-gen` package
- Updated tests for the new analytics algo
- Updated types definition for feature names

#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
