### PR TITLE
chore: override cheerio version to fix issues with parse5-parser-stream

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,5 +68,8 @@
   },
   "dependencies": {
     "@cloudinary/html": "^1.13.0"
+  },
+  "overrides": {
+    "cheerio": "1.0.0-rc.12"
   }
 }


### PR DESCRIPTION
### Pull request for cloudinary/frontend-frameworks

#### For which package is this PR?
* @cloudinary/react

#### What does this PR solve?
* Overrides `cheerio` in order to fix running tests due to issues with `parse5-parser-stream` 
* Related: https://github.com/inikulin/parse5/issues/1260


#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
- [ ] Relates to a github issue (link to issue).
