### PR TITLE
Add React performance warnings

### DIFF
--- a/packages/react/src/AdvancedImage.tsx
+++ b/packages/react/src/AdvancedImage.tsx
@@ -9,6 +9,7 @@ import {
   cancelCurrentlyRunningPlugins
 } from '@cloudinary/html'
 import { SDKAnalyticsConstants } from './internal/SDKAnalyticsConstants';
+import { warnOnOversizedImage, warnOnLazyLCP } from './internal/PerformanceWarnings';
 
 interface ImgProps {
   cldImg: CloudinaryImage;
@@ -84,6 +85,14 @@ class AdvancedImage extends React.Component <ImgProps> {
       this.props.plugins,
       SDKAnalyticsConstants
     )
+    if(NODE_ENV === 'development' && this.imageRef.current && !this.props["silence-warnings"]) {
+      warnOnLazyLCP(this.imageRef.current);
+      if(this.imageRef.current?.complete) {
+        warnOnOversizedImage(this.imageRef.current);
+      } else {
+        this.imageRef.current?.addEventListener('load', (e) => warnOnOversizedImage(e.currentTarget as HTMLImageElement));
+      }
+    }
   }
 
   /**

--- a/packages/react/src/internal/PerformanceWarnings.ts
+++ b/packages/react/src/internal/PerformanceWarnings.ts
@@ -1,0 +1,52 @@
+const OVERSIZE_IMAGE_TOLERANCE = 500
+
+let performanceObserver: PerformanceObserver
+
+export const warnOnOversizedImage = (image: HTMLImageElement) => {
+  const { clientWidth, clientHeight, naturalWidth, naturalHeight } = image
+  if (
+    naturalWidth > clientWidth + OVERSIZE_IMAGE_TOLERANCE ||
+    naturalHeight > clientHeight + OVERSIZE_IMAGE_TOLERANCE
+  ) {
+    console.warn(
+      `An image with URL ${image.src} has dimensions significantly smaller than intrinsic size, ` +
+        `and may slow down page load. You may address this by supplying a height and width for the image, ` +
+        `or by using the responsive image plugin. ` +
+        `Rendered size: ${clientWidth}x${clientHeight}. Intrinsic size: ${naturalWidth}x${naturalHeight}. ` +
+        `This warning can be surpressed by adding the 'silence-warnings' attribute to AdvancedImage.`
+    )
+  }
+}
+
+export const warnOnLazyLCP = (imgRef: HTMLImageElement) => {
+  if (
+    !performanceObserver &&
+    typeof window !== 'undefined' &&
+    window.PerformanceObserver
+  ) {
+    performanceObserver = new PerformanceObserver((entryList) => {
+      const entries = entryList.getEntries()
+
+      if (entries.length === 0) {
+        return
+      }
+
+      // The final LCP entry is the only one that can be the real LCP element. This cast is safe because
+      // this performanceObserver callback only listens for largest-contentful-paint events.
+      const lcpCandidate = entries[entries.length - 1] as LargestContentfulPaint
+
+      if (lcpCandidate.element?.getAttribute('loading') === 'lazy') {
+        console.warn(
+          `An image with URL ${imgRef.src} has ' loading="lazy"' and has also been detected to be a possible ` +
+            `LCP element (https://web.dev/lcp). This can have a significant negative impact on page loading performance. ` +
+            `To fix this issue, remove, 'loading="lazy"' from images which may render in the initial viewport. ` +
+            `This warning can be surpressed by adding the 'silence-warnings' attribute to AdvancedImage.`
+        )
+      }
+    })
+    performanceObserver.observe({
+      type: 'largest-contentful-paint',
+      buffered: true
+    })
+  }
+}


### PR DESCRIPTION
**Note**: This PR is currently a draft and untested, because of a build issue that currently prevents tests from running in the repo. @jerzy-mankowski has said they will address it when they have time. I will revise this PR afterward with a set of passing E2E tests at that time.

This PR includes a draft of 2 new performance warnings for the React AdvancedImage element. Please see the accompanying issue for a full description of the rationale for these two warnings.

The warnings are: 
**`warnOnOversizedImage`**: Logs a warning when an image is loaded, and the intrinsic size is greater than the rendered size by a substantial margin. That margin is defined in `OVERSIZE_IMAGE_TOLERANCE` and initially set to 500.
**`warnOnLazyLCP`**: Logs a warning when the [PerformanceObserver API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver) detects an image is a candidate for the [LCP image](https://web.dev/articles/lcp) but has been loaded with `loading=“lazy”`.

Both warnings only fire if the NODE_ENV variable is present (true in most React apps) and set to “development”. Both warnings can be silenced if the AdvancedImage element is given an attribute called “silence-warnings”.