### PR TITLE
fix(angular): fixed publish configuration for angular workspace

### DIFF
--- a/packages/angular/projects/cloudinary-library/ng-package.json
+++ b/packages/angular/projects/cloudinary-library/ng-package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "dist",
+  "dest": ".",
   "deleteDestPath": false,
   "lib": {
     "entryFile": "src/public_api.ts"

--- a/packages/angular/projects/cloudinary-library/ng-package.prod.json
+++ b/packages/angular/projects/cloudinary-library/ng-package.prod.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
-  "dest": "../../dist/cloudinary-library",
-  "lib": {
-    "entryFile": "src/public_api.ts"
-  }
-}

--- a/packages/angular/projects/cloudinary-library/package.json
+++ b/packages/angular/projects/cloudinary-library/package.json
@@ -16,5 +16,14 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "files": [
+    "bundles",
+    "esm2015",
+    "fesm2015",
+    "internal",
+    "lib",
+    "*.d.ts",
+    "*.md"
+  ]
 }


### PR DESCRIPTION
- removed unused ng-package files
- changed dist -> . to have it resolved in the way before version 2.1.2
- added `files` property to package.json to filter out irrelevant files